### PR TITLE
Support Promise for network related functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AMaaS Core features a secure, encrypted database, which serves as the foundation
 
 ```
 $ npm install
-$ npm test
+$ API_TOKEN=xxxxx npm test
 ```
 
 ## Contribution

--- a/dist/utils/assetManagers/assetManagers.js
+++ b/dist/utils/assetManagers/assetManagers.js
@@ -8,7 +8,6 @@ exports.insert = insert;
 exports.amendAM = amendAM;
 exports.deactivate = deactivate;
 exports._parseAM = _parseAM;
-exports._handleCallback = _handleCallback;
 
 var _network = require('../network');
 
@@ -31,13 +30,19 @@ function retrieve(_ref, callback) {
     AMaaSClass: 'assetManagers',
     AMId: AMId, token: token
   };
-  (0, _network.retrieveData)(params, function (error, result) {
-    if (error) {
-      callback(error);
-    } else {
-      var assetManager = _parseAM(result);
+  var promise = (0, _network.retrieveData)(params).then(function (result) {
+    var assetManager = _parseAM(result);
+    if (typeof callback === 'function') {
       callback(null, assetManager);
     }
+    return assetManager;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -50,14 +55,29 @@ function insert(_ref2, callback) {
   var assetManager = _ref2.assetManager,
       token = _ref2.token;
 
-  var stringified = JSON.stringify(assetManager);
+  var stringified = void 0,
+      data = void 0;
+  if (assetManager) {
+    stringified = JSON.stringify(assetManager);
+    data = JSON.parse(stringified);
+  }
   var params = {
     AMaaSClass: 'assetManagers',
-    data: JSON.parse(stringified),
+    data: data,
     token: token
   };
-  (0, _network.insertData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.insertData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -66,15 +86,30 @@ function amendAM(_ref3, callback) {
       AMId = _ref3.AMId,
       token = _ref3.token;
 
-  var stringified = JSON.stringify(assetManager);
+  var stringified = void 0,
+      data = void 0;
+  if (assetManager) {
+    stringified = JSON.stringify(assetManager);
+    data = JSON.parse(stringified);
+  }
   var params = {
     AMaaSClass: 'assetManagers',
     AMId: AMId,
-    data: JSON.parse(stringified),
+    data: data,
     token: token
   };
-  (0, _network.putData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.putData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -104,8 +139,18 @@ function deactivate(_ref4, callback) {
     AMId: AMId,
     token: token
   };
-  (0, _network.deleteData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.deleteData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -124,12 +169,4 @@ function _parseAM(object) {
     createdTime: object.created_time,
     updatedTime: object.updated_time
   });
-}
-
-function _handleCallback(error, result, callback) {
-  if (error) {
-    callback(error);
-  } else {
-    callback(null, result);
-  }
 }

--- a/dist/utils/assets/assets.js
+++ b/dist/utils/assets/assets.js
@@ -39,19 +39,25 @@ function retrieve(_ref, callback) {
     resourceId: resourceId,
     token: token
   };
-  (0, _network.retrieveData)(params, function (error, result) {
-    if (error) {
-      callback(error);
-    } else {
-      if (!Array.isArray(result)) {
-        callback(null, _parseAsset(result));
-        return;
-      }
-      var assets = result.map(function (asset) {
+  var promise = (0, _network.retrieveData)(params).then(function (result) {
+    if (Array.isArray(result)) {
+      result = result.map(function (asset) {
         return _parseAsset(asset);
       });
-      callback(null, assets);
+    } else {
+      result = _parseAsset(result);
     }
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -64,14 +70,29 @@ function insert(_ref2, callback) {
   var asset = _ref2.asset,
       token = _ref2.token;
 
-  var stringified = JSON.stringify(asset);
+  var stringified = void 0,
+      data = void 0;
+  if (asset) {
+    stringified = JSON.stringify(asset);
+    data = JSON.parse(stringified);
+  }
   var params = {
     AMaaSClass: 'assets',
-    data: JSON.parse(stringified),
+    data: data,
     token: token
   };
-  (0, _network.insertData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.insertData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -88,16 +109,31 @@ function amend(_ref3, callback) {
       resourceId = _ref3.resourceId,
       token = _ref3.token;
 
-  var stringified = JSON.stringify(asset);
+  var stringified = void 0,
+      data = void 0;
+  if (asset) {
+    stringified = JSON.stringify(asset);
+    data = JSON.parse(stringified);
+  }
   var params = {
     AMaaSClass: 'assets',
     AMId: AMId,
     resourceId: resourceId,
-    data: JSON.parse(stringified),
+    data: data,
     token: token
   };
-  (0, _network.putData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.putData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -121,8 +157,18 @@ function partialAmend(_ref4, callback) {
     data: changes,
     token: token
   };
-  (0, _network.patchData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.patchData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -140,10 +186,21 @@ function deactivate(_ref5, callback) {
   var params = {
     AMaaSClass: 'assets',
     AMId: AMId,
-    resourceId: resourceId
+    resourceId: resourceId,
+    token: token
   };
-  (0, _network.deleteData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.deleteData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -434,12 +491,4 @@ function _parseAsset(object) {
       });
   }
   return asset;
-}
-
-function _handleCallback(error, result, callback) {
-  if (error) {
-    callback(error);
-  } else {
-    callback(null, result);
-  }
 }

--- a/dist/utils/books/books.js
+++ b/dist/utils/books/books.js
@@ -32,19 +32,26 @@ function retrieve(_ref, callback) {
     resourceId: resourceId,
     token: token
   };
-  (0, _network.retrieveData)(params, function (error, result) {
-    if (error) {
-      callback(error);
-    } else {
-      if (!Array.isArray(result)) {
-        callback(null, _parseBook(result));
-        return;
-      }
-      var books = result.map(function (book) {
-        return _parseBook(book);
-      });
-      callback(null, books);
+  var promise = (0, _network.retrieveData)(params).then(function (result) {
+    if (!Array.isArray(result)) {
+      callback(null, _parseBook(result));
+      return;
     }
+    var books = result.map(function (book) {
+      return _parseBook(book);
+    });
+    if (typeof callback === 'function') {
+      callback(null, books);
+    } else {
+      return books;
+    }
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -59,15 +66,22 @@ function search(_ref2, callback) {
     queryValue: queryValue,
     token: token
   };
-  (0, _network.searchData)(params, function (error, result) {
-    if (error) {
-      callback(error);
-    } else {
-      var books = result.map(function (book) {
-        return _parseBook(book);
-      });
+  var promise = (0, _network.searchData)(params).then(function (result) {
+    var books = result.map(function (book) {
+      return _parseBook(book);
+    });
+    if (typeof callback === 'function') {
       callback(null, books);
+    } else {
+      return books;
     }
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 

--- a/dist/utils/network/index.js
+++ b/dist/utils/network/index.js
@@ -102,16 +102,22 @@ function retrieveData(_ref2, callback) {
   var url = buildURL({ AMaaSClass: AMaaSClass, AMId: AMId, resourceId: resourceId });
   // const url = resourceId ? `${baseURL}${AMaaSClass}/${AMId}/${resourceId}` : `${baseURL}${AMaaSClass}/${AMId}/`
 
-  _superagent2.default.get(url).set('Authorization', token).end(function (error, response) {
+  var promise = _superagent2.default.get(url).set('Authorization', token);
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise.then(function (response) {
+      return response.body;
+    });
+  }
+  promise.end(function (error, response) {
     if (!error && response.status == 200) {
       callback(null, response.body);
     } else {
       var statusCode = response ? response.status : '';
-      var requestError = {
-        statusCode: statusCode,
-        error: error
-      };
-      callback(requestError);
+      var requestError = { statusCode: statusCode, error: error };
+      if (typeof callback === 'function') {
+        callback(requestError);
+      }
     }
   });
 }
@@ -149,7 +155,14 @@ function insertData(_ref3, callback) {
     url: url,
     json: data
   };
-  _superagent2.default.post(url).send(data).set('Authorization', token).end(function (error, response) {
+  var promise = _superagent2.default.post(url).send(data).set('Authorization', token);
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise.then(function (response) {
+      return response.body;
+    });
+  }
+  promise.end(function (error, response) {
     var body = void 0;
     if (response) body = response.body;
     _networkCallback(error, response, body, callback);
@@ -175,7 +188,14 @@ function putData(_ref4, callback) {
     url: url,
     json: data
   };
-  _superagent2.default.put(url).send(data).set('Authorization', token).end(function (error, response) {
+  var promise = _superagent2.default.put(url).send(data).set('Authorization', token);
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise.then(function (response) {
+      return response.body;
+    });
+  }
+  promise.end(function (error, response) {
     var body = void 0;
     if (response) body = response.body;
     _networkCallback(error, response, body, callback);
@@ -201,7 +221,14 @@ function patchData(_ref5, callback) {
     url: url,
     json: data
   };
-  _superagent2.default.patch(url).send(data).set('Authorization', token).end(function (error, response) {
+  var promise = _superagent2.default.patch(url).send(data).set('Authorization', token);
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise.then(function (response) {
+      return response.body;
+    });
+  }
+  promise.end(function (error, response) {
     var body = void 0;
     if (response) body = response.body;
     _networkCallback(error, response, body, callback);
@@ -222,7 +249,14 @@ function deleteData(_ref6, callback) {
     AMId: AMId,
     resourceId: resourceId
   });
-  _superagent2.default.delete(url).set('Authorization', token).end(function (error, response) {
+  var promise = _superagent2.default.delete(url).set('Authorization', token);
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise.then(function (response) {
+      return response.body;
+    });
+  }
+  promise.end(function (error, response) {
     var body = void 0;
     if (response) body = response.body;
     _networkCallback(error, response, body, callback);
@@ -248,7 +282,14 @@ function searchData(_ref7, callback) {
     url: url,
     qs: qString
   };
-  _superagent2.default.get(url).set('Authorization', token).query(qString).end(function (error, response) {
+  var promise = _superagent2.default.get(url).set('Authorization', token).query(qString);
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise.then(function (response) {
+      return response.body;
+    });
+  }
+  promise.end(function (error, response) {
     var body = void 0;
     if (response) body = response.body;
     _networkCallback(error, response, body, callback);
@@ -256,6 +297,9 @@ function searchData(_ref7, callback) {
 }
 
 function _networkCallback(error, response, body, callback) {
+  if (typeof callback !== 'function') {
+    return false;
+  }
   if (!error && response.status === 200) {
     callback(null, body);
   } else if (error) {

--- a/dist/utils/parties/parties.js
+++ b/dist/utils/parties/parties.js
@@ -76,19 +76,25 @@ function retrieve(_ref, callback) {
     resourceId: partyId,
     token: token
   };
-  (0, _network.retrieveData)(params, function (error, result) {
-    if (error) {
-      callback(error);
-    } else {
-      if (!Array.isArray(result)) {
-        callback(null, _parseParty(result));
-        return;
-      }
-      var parties = result.map(function (party) {
+  var promise = (0, _network.retrieveData)(params).then(function (result) {
+    if (Array.isArray(result)) {
+      result = result.map(function (party) {
         return _parseParty(party);
       });
-      callback(null, parties);
+    } else {
+      result = _parseParty(result);
     }
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -101,14 +107,29 @@ function insert(_ref2, callback) {
   var party = _ref2.party,
       token = _ref2.token;
 
-  var stringified = JSON.stringify(party);
+  var stringified = void 0,
+      data = void 0;
+  if (party) {
+    stringified = JSON.stringify(party);
+    data = JSON.parse(stringified);
+  }
   var params = {
     AMaaSClass: 'parties',
-    data: JSON.parse(stringified),
+    data: data,
     token: token
   };
-  (0, _network.insertData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.insertData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -125,16 +146,31 @@ function amend(_ref3, callback) {
       resourceId = _ref3.resourceId,
       token = _ref3.token;
 
-  var stringified = JSON.stringify(party);
+  var stringified = void 0,
+      data = void 0;
+  if (party) {
+    stringified = JSON.stringify(party);
+    data = JSON.parse(stringified);
+  }
   var params = {
     AMaaSClass: 'parties',
     AMId: AMId,
     resourceId: resourceId,
-    data: JSON.parse(stringified),
+    data: data,
     token: token
   };
-  (0, _network.putData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.putData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -158,8 +194,18 @@ function partialAmend(_ref4, callback) {
     data: changes,
     token: token
   };
-  (0, _network.patchData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.patchData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -180,8 +226,18 @@ function deactivate(_ref5, callback) {
     resourceId: resourceId,
     token: token
   };
-  (0, _network.deleteData)(params, function (error, result) {
-    _handleCallback(error, result, callback);
+  var promise = (0, _network.deleteData)(params).then(function (result) {
+    if (typeof callback === 'function') {
+      callback(null, result);
+    }
+    return result;
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -393,14 +449,6 @@ function _parseParty(object) {
       });
   }
   return party;
-}
-
-function _handleCallback(error, result, callback) {
-  if (error) {
-    callback(error);
-  } else {
-    callback(null, _parseParty(result));
-  }
 }
 
 // export default getParty

--- a/dist/utils/positions/positions.js
+++ b/dist/utils/positions/positions.js
@@ -26,13 +26,20 @@ function retrieve(_ref, callback) {
     resourceId: resourceId,
     token: token
   };
-  (0, _network.retrieveData)(params, function (error, result) {
-    if (error) {
-      callback(error);
-    } else {
-      var pos = _parsePos(result);
+  var promise = (0, _network.retrieveData)(params).then(function (result) {
+    var pos = _parsePos(result);
+    if (typeof callback === 'function') {
       callback(null, pos);
+    } else {
+      return pos;
     }
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 
@@ -47,15 +54,22 @@ function search(_ref2, callback) {
     queryValue: queryValue,
     token: token
   };
-  (0, _network.searchData)(params, function (error, result) {
-    if (error) {
-      callback(error);
-    } else {
-      var positions = result.map(function (pos) {
-        return _parsePos(pos);
-      });
+  var promise = (0, _network.searchData)(params).then(function (result) {
+    var positions = result.map(function (pos) {
+      return _parsePos(pos);
+    });
+    if (typeof callback === 'function') {
       callback(null, positions);
+    } else {
+      return positions;
     }
+  });
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise;
+  }
+  promise.catch(function (error) {
+    return callback(error);
   });
 }
 

--- a/src/utils/assetManagers/assetManagers.js
+++ b/src/utils/assetManagers/assetManagers.js
@@ -31,10 +31,14 @@ export function retrieve({AMId, token}, callback) {
  * @param {function} callback - Called with two arguments (error, result) on completion
  */
 export function insert({assetManager, token}, callback) {
-  const stringified = JSON.stringify(assetManager)
+  let stringified, data
+  if (assetManager) {
+    stringified = JSON.stringify(assetManager)
+    data = JSON.parse(stringified)
+  }
   const params = {
     AMaaSClass: 'assetManagers',
-    data: JSON.parse(stringified),
+    data,
     token
   }
   let promise = insertData(params).then(result => {
@@ -51,11 +55,15 @@ export function insert({assetManager, token}, callback) {
 }
 
 export function amendAM({assetManager, AMId, token}, callback) {
-  const stringified = JSON.stringify(assetManager)
+  let stringified, data
+  if (assetManager) {
+    stringified = JSON.stringify(assetManager)
+    data = JSON.parse(stringified)
+  }
   const params = {
     AMaaSClass: 'assetManagers',
     AMId,
-    data: JSON.parse(stringified),
+    data,
     token
   }
   let promise = putData(params).then(result => {

--- a/src/utils/assetManagers/assetManagers.js
+++ b/src/utils/assetManagers/assetManagers.js
@@ -11,14 +11,18 @@ export function retrieve({AMId, token}, callback) {
     AMaaSClass: 'assetManagers',
     AMId, token
   }
-  retrieveData(params, (error, result) => {
-    if (error) {
-      callback(error)
-    } else {
-      const assetManager = _parseAM(result)
+  let promise = retrieveData(params).then(result => {
+    const assetManager = _parseAM(result)
+    if (typeof callback === 'function') {
       callback(null, assetManager)
     }
+    return assetManager
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -33,9 +37,17 @@ export function insert({assetManager, token}, callback) {
     data: JSON.parse(stringified),
     token
   }
-  insertData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = insertData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 export function amendAM({assetManager, AMId, token}, callback) {
@@ -46,9 +58,17 @@ export function amendAM({assetManager, AMId, token}, callback) {
     data: JSON.parse(stringified),
     token
   }
-  putData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = putData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 // export function partialAmendAM(changes, AMId, resourceId, callback) {
@@ -74,9 +94,17 @@ export function deactivate({AMId, token}, callback) {
     AMId,
     token
   }
-  deleteData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = deleteData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 export function _parseAM(object) {
@@ -94,12 +122,4 @@ export function _parseAM(object) {
     createdTime: object.created_time,
     updatedTime: object.updated_time
   })
-}
-
-export function _handleCallback(error, result, callback) {
-  if (error) {
-    callback(error)
-  } else {
-    callback(null, result)
-  }
 }

--- a/src/utils/assetManagers/assetManagers.test.js
+++ b/src/utils/assetManagers/assetManagers.test.js
@@ -1,21 +1,72 @@
 import { _parseAM, getAssetManager } from './assetManagers.js'
+import { retrieve, insert, amendAM, deactivate } from './assetManagers.js'
 import AssetManager from '../../assetManagers/AssetManager/assetManager.js'
 
-describe('_parseAM function', () => {
-  it('should return an instance of AssetManager class', () => {
-    const json = {
-      asset_manager_id: '48576',
-      client_id: 'testClient',
-      default_timezone: 'UTC',
-      version: 1
-    }
-    const parsedAM = _parseAM(json)
-    const expectedClass = new AssetManager({
-      assetManagerId: '48576',
-      clientId: 'testClient',
-      defaultTimezone: 'UTC',
-      version: 1
+let token = process.env.API_TOKEN
+
+describe('utils/assetManagers', () => {
+  describe('_parseAM function', () => {
+    it('should return an instance of AssetManager class', () => {
+      const json = {
+        asset_manager_id: '48576',
+        client_id: 'testClient',
+        default_timezone: 'UTC',
+        version: 1
+      }
+      const parsedAM = _parseAM(json)
+      const expectedClass = new AssetManager({
+        assetManagerId: '48576',
+        clientId: 'testClient',
+        defaultTimezone: 'UTC',
+        version: 1
+      })
+      expect(parsedAM).toEqual(expectedClass)
     })
-    expect(parsedAM).toEqual(expectedClass)
+  })
+
+
+  describe('retrieve', () => {
+    test('with promise', () => {
+      let promise = retrieve({
+        token, AMaaSClass: 'assetManagers', AMId: 1
+      }).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('retrieve', () => {
+    test('with promise', () => {
+      let promise = retrieve({
+        token, AMaaSClass: 'assetManagers', AMId: 1
+      }).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('insert', () => {
+    test('with promise', () => {
+      let promise = insert({
+        token, AMaaSClass: 'assetManagers', AMId: 1
+      }).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('amendAM', () => {
+    test('with promise', () => {
+      let promise = amendAM({
+        token, AMaaSClass: 'assetManagers', AMId: 1
+      }).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('deactivate', () => {
+    test('with promise', () => {
+      let promise = deactivate({
+        token, AMaaSClass: 'assetManagers', AMId: 1
+      }).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
   })
 })

--- a/src/utils/assets/assets.js
+++ b/src/utils/assets/assets.js
@@ -55,10 +55,14 @@ export function retrieve({AMId, resourceId, token}, callback) {
  * @param {function} callback - Called with two arguments (error, result) on completion
  */
 export function insert({asset, token}, callback) {
-  const stringified = JSON.stringify(asset)
+  let stringified, data
+  if (asset) {
+    stringified = JSON.stringify(asset)
+    data = JSON.parse(stringified)
+  }
   const params = {
     AMaaSClass: 'assets',
-    data: JSON.parse(stringified),
+    data,
     token
   }
   let promise = insertData(params).then(result => {
@@ -82,12 +86,16 @@ export function insert({asset, token}, callback) {
  * @param {function} callback - Called with two arguments (error, result) on completion
  */
 export function amend({asset, AMId, resourceId, token}, callback) {
-  const stringified = JSON.stringify(asset)
+  let stringified, data
+  if (asset) {
+    stringified = JSON.stringify(asset)
+    data = JSON.parse(stringified)
+  }
   const params = {
     AMaaSClass: 'assets',
     AMId,
     resourceId,
-    data: JSON.parse(stringified),
+    data,
     token
   }
   let promise = putData(params).then(result => {

--- a/src/utils/assets/assets.js
+++ b/src/utils/assets/assets.js
@@ -31,20 +31,22 @@ export function retrieve({AMId, resourceId, token}, callback) {
     resourceId,
     token
   }
-  retrieveData(params, (error, result) => {
-    if (error) {
-      callback(error)
+  let promise = retrieveData(params).then(result => {
+    if (Array.isArray(result)) {
+      result = result.map(asset => _parseAsset(asset))
     } else {
-      if (!Array.isArray(result)) {
-        callback(null, _parseAsset(result))
-        return
-      }
-      const assets = result.map(asset => {
-        return _parseAsset(asset)
-      })
-      callback(null, assets)
+      result = _parseAsset(result)
     }
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -59,9 +61,17 @@ export function insert({asset, token}, callback) {
     data: JSON.parse(stringified),
     token
   }
-  insertData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = insertData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -80,9 +90,17 @@ export function amend({asset, AMId, resourceId, token}, callback) {
     data: JSON.parse(stringified),
     token
   }
-  putData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = putData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -100,9 +118,17 @@ export function partialAmend({changes, AMId, resourceId, token}, callback) {
     data: changes,
     token
   }
-  patchData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = patchData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -117,9 +143,17 @@ export function deactivate({AMId, resourceId, token}, callback) {
     AMId,
     resourceId
   }
-  deleteData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = deleteData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 export function _parseAsset(object) {
@@ -409,12 +443,4 @@ export function _parseAsset(object) {
       })
   }
   return asset
-}
-
-function _handleCallback(error, result, callback) {
-  if (error) {
-    callback(error)
-  } else {
-    callback(null, result)
-  }
 }

--- a/src/utils/assets/assets.js
+++ b/src/utils/assets/assets.js
@@ -149,7 +149,8 @@ export function deactivate({AMId, resourceId, token}, callback) {
   const params = {
     AMaaSClass: 'assets',
     AMId,
-    resourceId
+    resourceId,
+    token
   }
   let promise = deleteData(params).then(result => {
     if (typeof callback === 'function') {

--- a/src/utils/assets/assets.test.js
+++ b/src/utils/assets/assets.test.js
@@ -1,27 +1,46 @@
 import { retrieve, insert, amend, partialAmend, deactivate } from './assets.js'
 import Asset from '../../assets/Asset/asset.js'
 
-describe('assets util functions', () => {
+let token = process.env.API_TOKEN
+
+describe('utils/assets', () => {
   describe('retrieve', () => {
-    it('should', () => {
-      // retrieve('1', '4bd2cfd84d154eef9b70f24262609a4b', (error, result) => {
-      //   if (!error) {
-      //     console.log(result)
-      //   }
-      // })
-      const asset = new Asset({
-        assetManagerId: '1',
-        fungible: true,
-        assetId:'test_asset',
-        description: 'testThomasAssetAmended'
+    test('with promise', callback => {
+      let promise = retrieve({token, AMId: 1})
+      expect(promise).toBeInstanceOf(Promise)
+      promise.then(assets => {
+        expect(Array.isArray(assets)).toBeTruthy()
+        expect(assets[0]).toBeInstanceOf(Asset)
+        callback()
       })
-      // amend(asset, '1', 'test_asset', (error, result) => {
-      //   if (error) {
-      //     console.log(error)
-      //   } else {
-      //     console.log(result)
-      //   }
-      // })
+    })
+  })
+
+  describe('insert', () => {
+    test('with promise', () => {
+      let promise = insert({token}).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('amend', () => {
+    test('with promise', () => {
+      let promise = amend({token}).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('partialAmend', () => {
+    test('with promise', () => {
+      let promise = partialAmend({token}).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('deactivate', () => {
+    test('with promise', () => {
+      let promise = deactivate({token}).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
     })
   })
 })

--- a/src/utils/books/books.js
+++ b/src/utils/books/books.js
@@ -14,7 +14,7 @@ export function retrieve({AMId, resourceId, token}, callback) {
     resourceId,
     token
   }
-  let handleFullfilled = result => {
+  let promise = retrieveData(params).then(result => {
     if (!Array.isArray(result)) {
       callback(null, _parseBook(result))
       return
@@ -27,8 +27,7 @@ export function retrieve({AMId, resourceId, token}, callback) {
     } else {
       return books
     }
-  }
-  let promise = retrieveData(params).then(handleFullfilled)
+  })
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise
@@ -43,7 +42,7 @@ export function search({queryKey, queryValue, token}, callback) {
     queryValue,
     token
   }
-  let handleFullfilled = result => {
+  let promise = searchData(params).then(result => {
     const books = result.map((book) => {
       return _parseBook(book)
     })
@@ -52,8 +51,7 @@ export function search({queryKey, queryValue, token}, callback) {
     } else {
       return books
     }
-  }
-  let promise = searchData(params).then(handleFullfilled)
+  })
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise

--- a/src/utils/books/books.js
+++ b/src/utils/books/books.js
@@ -14,20 +14,26 @@ export function retrieve({AMId, resourceId, token}, callback) {
     resourceId,
     token
   }
-  retrieveData(params, (error, result) => {
-    if (error) {
-      callback(error)
-    } else {
-      if (!Array.isArray(result)) {
-        callback(null, _parseBook(result))
-        return
-      }
-      const books = result.map(book => {
-        return _parseBook(book)
-      })
-      callback(null, books)
+  let handleFullfilled = result => {
+    if (!Array.isArray(result)) {
+      callback(null, _parseBook(result))
+      return
     }
-  })
+    const books = result.map(book => {
+      return _parseBook(book)
+    })
+    if (typeof callback === 'function') {
+      callback(null, books)
+    } else {
+      return books
+    }
+  }
+  let promise = retrieveData(params).then(handleFullfilled)
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 export function search({queryKey, queryValue, token}, callback) {
@@ -37,16 +43,22 @@ export function search({queryKey, queryValue, token}, callback) {
     queryValue,
     token
   }
-  searchData(params, (error, result) => {
-    if (error) {
-      callback(error)
-    } else {
-      const books = result.map((book) => {
-        return _parseBook(book)
-      })
+  let handleFullfilled = result => {
+    const books = result.map((book) => {
+      return _parseBook(book)
+    })
+    if (typeof callback === 'function') {
       callback(null, books)
+    } else {
+      return books
     }
-  })
+  }
+  let promise = searchData(params).then(handleFullfilled)
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 export function _parseBook(object) {

--- a/src/utils/books/books.test.js
+++ b/src/utils/books/books.test.js
@@ -6,45 +6,49 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
 let token = process.env.API_TOKEN
 
 describe('utils/books', () => {
-  test("retrieve with callback", callback => {
-    retrieve({token, AMId: 1}, (error, books) => {
-      expect(Array.isArray(books)).toBeTruthy()
-      expect(books[0]).toBeInstanceOf(Book)
-      callback(error)
+  describe('retrieve', () => {
+    test('with callback', callback => {
+      retrieve({token, AMId: 1}, (error, books) => {
+        expect(Array.isArray(books)).toBeTruthy()
+        expect(books[0]).toBeInstanceOf(Book)
+        callback(error)
+      })
+    })
+
+    test('with promise', callback => {
+      let promise = retrieve({token, AMId: 1})
+      expect(promise).toBeInstanceOf(Promise)
+      promise.then(books => {
+        expect(Array.isArray(books)).toBeTruthy()
+        expect(books[0]).toBeInstanceOf(Book)
+        callback()
+      })
     })
   })
 
-  test("retrieve with promise", callback => {
-    let promise = retrieve({token, AMId: 1})
-    expect(promise).toBeInstanceOf(Promise)
-    promise.then(books => {
-      expect(Array.isArray(books)).toBeTruthy()
-      expect(books[0]).toBeInstanceOf(Book)
-      callback()
+  describe('search', () => {
+    test('with callback', callback => {
+      search({
+        token,
+        queryKey: 'asset_manager_ids',
+        queryValue: [269]
+      }, (error, books) => {
+        expect(Array.isArray(books)).toBeTruthy()
+        callback(error)
+      })
     })
-  })
 
-  test("search with callback", callback => {
-    search({
-      token,
-      queryKey: 'asset_manager_ids',
-      queryValue: [269]
-    }, (error, books) => {
-      expect(Array.isArray(books)).toBeTruthy()
-      callback(error)
-    })
-  })
-
-  test("search with promise", callback => {
-    let promise = search({
-      token,
-      queryKey: 'asset_manager_ids',
-      queryValue: [269]
-    })
-    expect(promise).toBeInstanceOf(Promise)
-    promise.then(books => {
-      expect(Array.isArray(books)).toBeTruthy()
-      callback()
+    test('with promise', callback => {
+      let promise = search({
+        token,
+        queryKey: 'asset_manager_ids',
+        queryValue: [269]
+      })
+      expect(promise).toBeInstanceOf(Promise)
+      promise.then(books => {
+        expect(Array.isArray(books)).toBeTruthy()
+        callback()
+      })
     })
   })
 })

--- a/src/utils/books/books.test.js
+++ b/src/utils/books/books.test.js
@@ -1,26 +1,50 @@
 import { retrieve, search } from './books'
 import Book from '../../books/Book/book'
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
+
+let token = process.env.API_TOKEN
+
 describe('utils/books', () => {
-  test.skip("retrieve", callback => {
-    retrieve({
-      AMId: 1,
-      token: 'testToken'
-    }, (error, result) => {
-      expect(Array.isArray(result)).toBeTruthy()
-      expect(result[0]).toBeInstanceOf(Book)
+  test("retrieve with callback", callback => {
+    retrieve({token, AMId: 1}, (error, books) => {
+      expect(Array.isArray(books)).toBeTruthy()
+      expect(books[0]).toBeInstanceOf(Book)
       callback(error)
     })
   })
 
-  test("search", callback => {
+  test("retrieve with promise", callback => {
+    let promise = retrieve({token, AMId: 1})
+    expect(promise).toBeInstanceOf(Promise)
+    promise.then(books => {
+      expect(Array.isArray(books)).toBeTruthy()
+      expect(books[0]).toBeInstanceOf(Book)
+      callback()
+    })
+  })
+
+  test("search with callback", callback => {
     search({
+      token,
       queryKey: 'asset_manager_ids',
       queryValue: [269]
-    }, (error, result) => {
-      console.log(result)
-      expect(Array.isArray(result)).toBeTruthy()
+    }, (error, books) => {
+      expect(Array.isArray(books)).toBeTruthy()
       callback(error)
+    })
+  })
+
+  test("search with promise", callback => {
+    let promise = search({
+      token,
+      queryKey: 'asset_manager_ids',
+      queryValue: [269]
+    })
+    expect(promise).toBeInstanceOf(Promise)
+    promise.then(books => {
+      expect(Array.isArray(books)).toBeTruthy()
+      callback()
     })
   })
 })

--- a/src/utils/network/index.js
+++ b/src/utils/network/index.js
@@ -73,16 +73,22 @@ export function retrieveData({ AMaaSClass, AMId, resourceId, token }, callback) 
   const url = buildURL({ AMaaSClass, AMId, resourceId })
   // const url = resourceId ? `${baseURL}${AMaaSClass}/${AMId}/${resourceId}` : `${baseURL}${AMaaSClass}/${AMId}/`
 
-  request.get(url).set('Authorization', token).end((error, response) => {
+  let promise = request.get(url).set('Authorization', token)
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.end((error, response) => {
     if (!error && response.status == 200) {
-      callback(null, response.body)
+      if (typeof callback === 'function') {
+        callback(null, response.body)
+      }
     } else {
       const statusCode = response ? response.status : ''
-      const requestError = {
-        statusCode,
-        error
+      const requestError = {statusCode, error}
+      if (typeof callback === 'function') {
+        callback(requestError)
       }
-      callback(requestError)
     }
   })
 }
@@ -115,7 +121,12 @@ export function insertData({ AMaaSClass, AMId, data, token }, callback) {
     url,
     json: data
   }
-  request.post(url).send(data).set('Authorization', token).end((error, response) => {
+  let promise = request.post(url).send(data).set('Authorization', token)
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.end((error, response) => {
     let body
     if (response) body = response.body
     _networkCallback(error, response, body, callback)
@@ -135,7 +146,12 @@ export function putData({ AMaaSClass, AMId, resourceId, data, token }, callback)
     url,
     json: data
   }
-  request.put(url).send(data).set('Authorization', token).end((error, response) => {
+  let promise = request.put(url).send(data).set('Authorization', token)
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.end((error, response) => {
     let body
     if (response) body = response.body
     _networkCallback(error, response, body, callback)
@@ -155,7 +171,12 @@ export function patchData({ AMaaSClass, AMId, resourceId, data, token }, callbac
     url,
     json: data
   }
-  request.patch(url).send(data).set('Authorization', token).end((error, response) => {
+  let promise = request.patch(url).send(data).set('Authorization', token)
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.end((error, response) => {
     let body
     if (response) body = response.body
     _networkCallback(error, response, body, callback)
@@ -171,7 +192,12 @@ export function deleteData({ AMaaSClass, AMId, resourceId, token }, callback) {
     AMId,
     resourceId
   })
-  request.delete(url).set('Authorization', token).end((error, response) => {
+  let promise = request.delete(url).set('Authorization', token)
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.end((error, response) => {
     let body
     if (response) body = response.body
     _networkCallback(error, response, body, callback)
@@ -192,7 +218,12 @@ export function searchData({ AMaaSClass, queryKey, queryValue, token }, callback
     url,
     qs: qString
   }
-  request.get(url).set('Authorization', token).query(qString).end((error, response) => {
+  let promise = request.get(url).set('Authorization', token).query(qString)
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.end((error, response) => {
     let body
     if (response) body = response.body
     _networkCallback(error, response, body, callback)
@@ -200,6 +231,9 @@ export function searchData({ AMaaSClass, queryKey, queryValue, token }, callback
 }
 
 function _networkCallback(error, response, body, callback) {
+  if (typeof callback !== 'function') {
+    return false
+  }
   if (!error && response.status === 200) {
     callback(null, body)
   } else if (error) {

--- a/src/utils/network/index.js
+++ b/src/utils/network/index.js
@@ -76,13 +76,11 @@ export function retrieveData({ AMaaSClass, AMId, resourceId, token }, callback) 
   let promise = request.get(url).set('Authorization', token)
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
-    return promise
+    return promise.then(response => response.body)
   }
   promise.end((error, response) => {
     if (!error && response.status == 200) {
-      if (typeof callback === 'function') {
-        callback(null, response.body)
-      }
+      callback(null, response.body)
     } else {
       const statusCode = response ? response.status : ''
       const requestError = {statusCode, error}
@@ -124,7 +122,7 @@ export function insertData({ AMaaSClass, AMId, data, token }, callback) {
   let promise = request.post(url).send(data).set('Authorization', token)
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
-    return promise
+    return promise.then(response => response.body)
   }
   promise.end((error, response) => {
     let body
@@ -149,7 +147,7 @@ export function putData({ AMaaSClass, AMId, resourceId, data, token }, callback)
   let promise = request.put(url).send(data).set('Authorization', token)
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
-    return promise
+    return promise.then(response => response.body)
   }
   promise.end((error, response) => {
     let body
@@ -174,7 +172,7 @@ export function patchData({ AMaaSClass, AMId, resourceId, data, token }, callbac
   let promise = request.patch(url).send(data).set('Authorization', token)
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
-    return promise
+    return promise.then(response => response.body)
   }
   promise.end((error, response) => {
     let body
@@ -195,7 +193,7 @@ export function deleteData({ AMaaSClass, AMId, resourceId, token }, callback) {
   let promise = request.delete(url).set('Authorization', token)
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
-    return promise
+    return promise.then(response => response.body)
   }
   promise.end((error, response) => {
     let body
@@ -221,7 +219,7 @@ export function searchData({ AMaaSClass, queryKey, queryValue, token }, callback
   let promise = request.get(url).set('Authorization', token).query(qString)
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
-    return promise
+    return promise.then(response => response.body)
   }
   promise.end((error, response) => {
     let body

--- a/src/utils/network/network.test.js
+++ b/src/utils/network/network.test.js
@@ -2,7 +2,10 @@ import {
   buildURL,
   retrieveData,
   insertData,
-  searchData
+  searchData,
+  putData,
+  patchData,
+  deleteData
 } from './'
 
 import ENDPOINTS from '../../config.js'
@@ -10,6 +13,8 @@ import ENDPOINTS from '../../config.js'
 // import { baseURL } from './constants.js'
 
 import nock from 'nock'
+
+let token = process.env.API_TOKEN
 
 describe('buildURL function', () => {
   it('should throw if no class supplied', () => {
@@ -68,6 +73,10 @@ describe('retrieveData', () => {
       callback()
     })
   })
+  it('should return a promise if callback is not provided', () => {
+    let promise = retrieveData(testParams).catch(error => {})
+    expect(promise).toBeInstanceOf(Promise)
+  })
 })
 
 describe('insertData', () => {
@@ -97,6 +106,10 @@ describe('insertData', () => {
       callback()
     })
   })
+  it('should return a promise if callback is not provided', () => {
+    let promise = insertData(testParams).catch(error => {})
+    expect(promise).toBeInstanceOf(Promise)
+  })
 })
 
 describe('searchData', () => {
@@ -109,6 +122,10 @@ describe('searchData', () => {
   const expectedResult = {
     asset_book_id: '1,2,3,abc'
   }
+  it('should return a promise if callback is not provided', () => {
+    let promise = searchData(testParams).catch(error => {})
+    expect(promise).toBeInstanceOf(Promise)
+  })
   // searchData(testParams, (error, result) => {
   //   if (error) {
   //     console.log(error)
@@ -119,4 +136,20 @@ describe('searchData', () => {
   // searchData(testParams, (error, result) => {
   //   expect(result).toEqual(expectedResult)
   // })
+})
+
+describe('putData', () => {
+  let params = {token, AMaaSClass: 'positions'}
+  it('should return a promise if callback is not provided', () => {
+    let promise = putData(params).catch(error => {})
+    expect(promise).toBeInstanceOf(Promise)
+  })
+})
+
+describe('patchData', () => {
+  let params = {token, AMaaSClass: 'positions'}
+  it('should return a promise if callback is not provided', () => {
+    let promise = patchData(params).catch(error => {})
+    expect(promise).toBeInstanceOf(Promise)
+  })
 })

--- a/src/utils/parties/parties.js
+++ b/src/utils/parties/parties.js
@@ -49,10 +49,14 @@ export function retrieve({AMId, partyId, token}, callback) {
  * @param {function} callback - Called with two arguments (error, result) on completion
  */
 export function insert({party, token}, callback) {
-  const stringified = JSON.stringify(party)
+  let stringified, data
+  if (party) {
+    stringified = JSON.stringify(party)
+    data = JSON.parse(stringified)
+  }
   const params = {
     AMaaSClass: 'parties',
-    data: JSON.parse(stringified),
+    data,
     token
   }
   let promise = insertData(params).then(result => {
@@ -76,12 +80,16 @@ export function insert({party, token}, callback) {
  * @param {function} callback - Called with two arguments (error, result) on completion
  */
 export function amend({party, AMId, resourceId, token}, callback) {
-  const stringified = JSON.stringify(party)
+  let stringified, data
+  if (party) {
+    stringified = JSON.stringify(party)
+    data = JSON.parse(stringified)
+  }
   const params = {
     AMaaSClass: 'parties',
     AMId,
     resourceId,
-    data: JSON.parse(stringified),
+    data,
     token
   }
   let promise = putData(params).then(result => {

--- a/src/utils/parties/parties.js
+++ b/src/utils/parties/parties.js
@@ -25,20 +25,22 @@ export function retrieve({AMId, partyId, token}, callback) {
     resourceId: partyId,
     token
   }
-  retrieveData(params, (error, result) => {
-    if (error) {
-      callback(error)
+  let promise = retrieveData(params).then(result => {
+    if (Array.isArray(result)) {
+      result = result.map(party => _parseParty(party))
     } else {
-      if (!Array.isArray(result)) {
-        callback(null, _parseParty(result))
-        return
-      }
-      const parties = result.map(party => {
-        return _parseParty(party)
-      })
-      callback(null, parties)
+      result = _parseParty(result)
     }
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -53,9 +55,17 @@ export function insert({party, token}, callback) {
     data: JSON.parse(stringified),
     token
   }
-  insertData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = insertData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -74,9 +84,17 @@ export function amend({party, AMId, resourceId, token}, callback) {
     data: JSON.parse(stringified),
     token
   }
-  putData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = putData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -94,9 +112,17 @@ export function partialAmend({changes, AMId, resourceId, token}, callback) {
     data: changes,
     token
   }
-  patchData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = patchData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 /**
@@ -112,9 +138,17 @@ export function deactivate({AMId, resourceId, token}, callback) {
     resourceId,
     token
   }
-  deleteData(params, (error, result) => {
-    _handleCallback(error, result, callback)
+  let promise = deleteData(params).then(result => {
+    if (typeof callback === 'function') {
+      callback(null, result)
+    }
+    return result
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 export function _parseChildren(type, children) {
@@ -325,14 +359,6 @@ export function _parseParty(object) {
       })
   }
   return party
-}
-
-function _handleCallback(error, result, callback) {
-  if (error) {
-    callback(error)
-  } else {
-    callback(null, _parseParty(result))
-  }
 }
 
 // export default getParty

--- a/src/utils/parties/parties.test.js
+++ b/src/utils/parties/parties.test.js
@@ -5,6 +5,8 @@ import Party from '../../parties/Party/party.js'
 import Broker from '../../parties/Broker/broker.js'
 import Address from '../../parties/Children/address.js'
 
+let token = process.env.API_TOKEN
+
 describe('parties util functions', () => {
   describe('insert function', () => {
     it('should stringify party correctly', () => {
@@ -48,7 +50,12 @@ describe('parties util functions', () => {
       //   // no-op
       // })
     })
+    test('with promise', () => {
+      let promise = insert({token})
+      expect(promise).toBeInstanceOf(Promise)
+    })
   })
+
   describe('retrieve function', () => {
     it('should call callback with error if retrieveData fails', callback => {
       nock(ENDPOINTS.parties)
@@ -70,7 +77,33 @@ describe('parties util functions', () => {
         callback()
       })
     })
+    test('with promise', () => {
+      let promise = retrieve({AMId: 1, partyId: 'party', token})
+      expect(promise).toBeInstanceOf(Promise)
+    })
   })
+
+  describe('amend', () => {
+    test('with promise', () => {
+      let promise = amend({token}).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('partialAmend', () => {
+    test('with promise', () => {
+      let promise = partialAmend({token}).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
+  describe('deactivate', () => {
+    test('with promise', () => {
+      let promise = deactivate({token}).catch(error => {})
+      expect(promise).toBeInstanceOf(Promise)
+    })
+  })
+
   describe('_parseParty function', () => {
     it('should parse the response to the appropriate class', () => {
       const address = new Address({

--- a/src/utils/parties/parties.test.js
+++ b/src/utils/parties/parties.test.js
@@ -39,7 +39,6 @@ describe('parties util functions', () => {
         version: 1,
       })
       const party = new Party({ assetManagerId: '1234', partyId: 'AMID1234', addresses: { Registered: address, Legal: address2 }, createdBy: 'TEMP' })
-      console.log(JSON.stringify(party))
       // retrieve('646', '30', (error, result) => {
       //   if (result) {
       //     console.log(result)
@@ -57,7 +56,7 @@ describe('parties util functions', () => {
         .reply(400)
       retrieve({AMId: 1, partyId: 'party', token: 'testToken'}, (error, result) => {
         expect(result).toBeUndefined()
-        expect(error.statusCode).toBe(400)
+        expect(error.status).toBe(400)
         callback()
       })
     })

--- a/src/utils/parties/parties.test.js
+++ b/src/utils/parties/parties.test.js
@@ -51,7 +51,7 @@ describe('parties util functions', () => {
       // })
     })
     test('with promise', () => {
-      let promise = insert({token})
+      let promise = insert({token}).catch(error => {})
       expect(promise).toBeInstanceOf(Promise)
     })
   })
@@ -78,7 +78,9 @@ describe('parties util functions', () => {
       })
     })
     test('with promise', () => {
-      let promise = retrieve({AMId: 1, partyId: 'party', token})
+      let promise = retrieve({
+        AMId: 1, partyId: 'party', token
+      }).catch(error => {})
       expect(promise).toBeInstanceOf(Promise)
     })
   })

--- a/src/utils/positions/positions.js
+++ b/src/utils/positions/positions.js
@@ -9,14 +9,19 @@ export function retrieve({AMId, resourceId, token}, callback) {
     resourceId,
     token
   }
-  retrieveData(params, (error, result) => {
-    if (error) {
-      callback(error)
-    } else {
-      const pos = _parsePos(result)
+  let promise = retrieveData(params).then(result => {
+    const pos = _parsePos(result)
+    if (typeof callback === 'function') {
       callback(null, pos)
+    } else {
+      return pos
     }
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 export function search({queryKey, queryValue, token}, callback) {
@@ -26,16 +31,21 @@ export function search({queryKey, queryValue, token}, callback) {
     queryValue,
     token
   }
-  searchData(params, (error, result) => {
-    if (error) {
-      callback(error)
-    } else {
-      const positions = result.map((pos) => {
-        return _parsePos(pos)
-      })
+  let promise = searchData(params).then(result => {
+    const positions = result.map((pos) => {
+      return _parsePos(pos)
+    })
+    if (typeof callback === 'function') {
       callback(null, positions)
+    } else {
+      return positions
     }
   })
+  if (typeof callback !== 'function') {
+    // return promise if callback is not provided
+    return promise
+  }
+  promise.catch(error => callback(error))
 }
 
 export function _parsePos(pos) {

--- a/src/utils/positions/positions.test.js
+++ b/src/utils/positions/positions.test.js
@@ -1,12 +1,34 @@
 import { search } from './positions.js'
 import Position from '../../transactions/Positions/position.js'
 
-describe('Position search API', () => {
-  it.skip('should return an array of Position objects', callback => {
-    search({queryKey: 'asset_manager_book_id', queryValue: [7], token: 'testToken'}, (error, result) => {
-      expect(Array.isArray(result)).toBeTruthy()
-      expect(result[0]).toBeInstanceOf(Position)
-      callback(error)
+let token = process.env.API_TOKEN
+
+describe('utils/positions', () => {
+  describe('search', () => {
+    test('with callback', callback => {
+      search({
+        token,
+        queryKey: 'asset_manager_ids',
+        queryValue: [269]
+      }, (error, positions) => {
+        expect(Array.isArray(positions)).toBeTruthy()
+        expect(positions[0]).toBeInstanceOf(Position)
+        callback(error)
+      })
+    })
+
+    test('with promise', callback => {
+      let promise = search({
+        token,
+        queryKey: 'asset_manager_ids',
+        queryValue: [269]
+      })
+      expect(promise).toBeInstanceOf(Promise)
+      promise.then(positions => {
+        expect(Array.isArray(positions)).toBeTruthy()
+        expect(positions[0]).toBeInstanceOf(Position)
+        callback()
+      })
     })
   })
 })


### PR DESCRIPTION
This PR adds Promise for network related functions, as an alternative to using callback.
Passing callback to the functions is still supported.

It uses native Promise. A polyfill will be needed if the browser or Node version does not support native Promise.