### PR TITLE
Restore default JSON.stringify() functionality

### DIFF
--- a/dist/assetManagers/AssetManager/assetManager.js
+++ b/dist/assetManagers/AssetManager/assetManager.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _core = require('../../core');
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -74,26 +72,26 @@ var AssetManager = function (_AMaaSModel) {
     return _this;
   }
 
-  _createClass(AssetManager, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        asset_manager_type: this.assetManagerType,
-        asset_manager_status: this.assetManagerStatus,
-        client_id: this.clientId,
-        party_id: this.partyId,
-        default_book_owner_id: this.defaultBookOwnerId,
-        default_timezone: this.defaultTimezone,
-        default_book_close_time: this.defaultBookCloseTime,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      asset_manager_type: this.assetManagerType,
+      asset_manager_status: this.assetManagerStatus,
+      client_id: this.clientId,
+      party_id: this.partyId,
+      default_book_owner_id: this.defaultBookOwnerId,
+      default_timezone: this.defaultTimezone,
+      default_book_close_time: this.defaultBookCloseTime,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return AssetManager;
 }(_core.AMaaSModel);

--- a/dist/assets/Asset/asset.js
+++ b/dist/assets/Asset/asset.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _core = require('../../core');
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -93,31 +91,31 @@ var Asset = function (_AMaaSModel) {
     return _this;
   }
 
-  _createClass(Asset, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Asset;
 }(_core.AMaaSModel);

--- a/dist/assets/Bond/BondBase/bond.js
+++ b/dist/assets/Bond/BondBase/bond.js
@@ -106,33 +106,6 @@ var BondBase = function (_Asset) {
   }
 
   _createClass(BondBase, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        issue_date: this.issueDate,
-        coupon: this.coupon,
-        par: this.par,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
-    }
-  }, {
     key: 'coupon',
     set: function set(newCoupon) {
       switch (newCoupon) {
@@ -183,6 +156,35 @@ var BondBase = function (_Asset) {
     get: function get() {
       return this._defaulted;
     }
+
+    /*
+    toJSON() {
+      return {
+        asset_manager_id: this.assetManagerId,
+        fungible: this.fungible,
+        asset_issuer_id: this.assetIssuerId,
+        asset_id: this.assetId,
+        asset_class: this.assetClass,
+        asset_type: this.assetType,
+        asset_status: this.assetStatus,
+        country_id: this.countryId,
+        venue_id: this.venueId,
+        maturity_date: this.maturityDate,
+        description: this.description,
+        client_id: this.clientId,
+        issue_date: this.issueDate,
+        coupon: this.coupon,
+        par: this.par,
+        references: this.references,
+        created_by: this.createdBy,
+        updated_by: this.updatedBy,
+        created_time: this.createdTime,
+        updated_time: this.updatedTime,
+        version: this.version
+      }
+    }
+    */
+
   }]);
 
   return BondBase;

--- a/dist/assets/Bond/BondCorporate/bondCorporate.js
+++ b/dist/assets/Bond/BondCorporate/bondCorporate.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _bond = require('../BondBase/bond.js');
 
 var _bond2 = _interopRequireDefault(_bond);
@@ -76,34 +74,34 @@ var BondCorporate = function (_BondBase) {
     }));
   }
 
-  _createClass(BondCorporate, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        issue_date: this.issueDate,
-        coupon: this.coupon,
-        par: this.par,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      issue_date: this.issueDate,
+      coupon: this.coupon,
+      par: this.par,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return BondCorporate;
 }(_bond2.default);

--- a/dist/assets/Bond/BondGovernment/bondGovernment.js
+++ b/dist/assets/Bond/BondGovernment/bondGovernment.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _bond = require('../BondBase/bond.js');
 
 var _bond2 = _interopRequireDefault(_bond);
@@ -76,34 +74,34 @@ var BondGovernment = function (_BondBase) {
     }));
   }
 
-  _createClass(BondGovernment, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        issue_date: this.issueDate,
-        coupon: this.coupon,
-        par: this.par,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      issue_date: this.issueDate,
+      coupon: this.coupon,
+      par: this.par,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return BondGovernment;
 }(_bond2.default);

--- a/dist/assets/Bond/BondMortgage/bondMortgage.js
+++ b/dist/assets/Bond/BondMortgage/bondMortgage.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _bond = require('../BondBase/bond.js');
 
 var _bond2 = _interopRequireDefault(_bond);
@@ -76,34 +74,34 @@ var BondMortgage = function (_BondBase) {
     }));
   }
 
-  _createClass(BondMortgage, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        issue_date: this.issueDate,
-        coupon: this.coupon,
-        par: this.par,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      issue_date: this.issueDate,
+      coupon: this.coupon,
+      par: this.par,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return BondMortgage;
 }(_bond2.default);

--- a/dist/assets/Currency/currency.js
+++ b/dist/assets/Currency/currency.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _asset = require('../Asset/asset.js');
 
 var _asset2 = _interopRequireDefault(_asset);
@@ -74,32 +72,32 @@ var Currency = function (_Asset) {
     return _this;
   }
 
-  _createClass(Currency, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        deliverable: this.deliverable,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      deliverable: this.deliverable,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Currency;
 }(_asset2.default);

--- a/dist/assets/Derivative/BondOption/bondOption.js
+++ b/dist/assets/Derivative/BondOption/bondOption.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _derivative = require('../Derivative/derivative.js');
 
 var _derivative2 = _interopRequireDefault(_derivative);
@@ -78,34 +76,34 @@ var BondOption = function (_Derivative) {
     return _this;
   }
 
-  _createClass(BondOption, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        issue_date: this.issueDate,
-        put_call: this.putCall,
-        strike: this.strike,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      issue_date: this.issueDate,
+      put_call: this.putCall,
+      strike: this.strike,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return BondOption;
 }(_derivative2.default);

--- a/dist/assets/Derivative/Derivative/derivative.js
+++ b/dist/assets/Derivative/Derivative/derivative.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _asset = require('../../Asset/asset.js');
 
 var _asset2 = _interopRequireDefault(_asset);
@@ -74,32 +72,32 @@ var Derivative = function (_Asset) {
     return _this;
   }
 
-  _createClass(Derivative, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        issue_date: this.issueDate,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      issue_date: this.issueDate,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Derivative;
 }(_asset2.default);

--- a/dist/assets/Equity/equity.js
+++ b/dist/assets/Equity/equity.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _asset = require('../Asset/asset.js');
 
 var _asset2 = _interopRequireDefault(_asset);
@@ -70,31 +68,31 @@ var Equity = function (_Asset) {
     }));
   }
 
-  _createClass(Equity, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Equity;
 }(_asset2.default);

--- a/dist/assets/FX/FXBase/fxBase.js
+++ b/dist/assets/FX/FXBase/fxBase.js
@@ -80,9 +80,9 @@ var FXBase = function (_Asset) {
     value: function getCounterCurrency() {
       return this.assetId.slice(3, 7);
     }
-  }, {
-    key: 'toJSON',
-    value: function toJSON() {
+
+    /*
+    toJSON() {
       return {
         asset_manager_id: this.assetManagerId,
         fungible: this.fungible,
@@ -102,8 +102,10 @@ var FXBase = function (_Asset) {
         created_time: this.createdTime,
         updated_time: this.updatedTime,
         version: this.version
-      };
+      }
     }
+    */
+
   }]);
 
   return FXBase;

--- a/dist/assets/FX/ForeignExchange/foreignExchange.js
+++ b/dist/assets/FX/ForeignExchange/foreignExchange.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _fxBase = require('../FXBase/fxBase.js');
 
 var _fxBase2 = _interopRequireDefault(_fxBase);
@@ -70,31 +68,31 @@ var ForeignExchange = function (_FXBase) {
     }));
   }
 
-  _createClass(ForeignExchange, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return ForeignExchange;
 }(_fxBase2.default);

--- a/dist/assets/FX/NonDeliverableForward/nonDeliverableForward.js
+++ b/dist/assets/FX/NonDeliverableForward/nonDeliverableForward.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _fxBase = require('../FXBase/fxBase.js');
 
 var _fxBase2 = _interopRequireDefault(_fxBase);
@@ -70,31 +68,31 @@ var NonDeliverableForward = function (_FXBase) {
     }));
   }
 
-  _createClass(NonDeliverableForward, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        fungible: this.fungible,
-        asset_issuer_id: this.assetIssuerId,
-        asset_id: this.assetId,
-        asset_class: this.assetClass,
-        asset_type: this.assetType,
-        asset_status: this.assetStatus,
-        country_id: this.countryId,
-        venue_id: this.venueId,
-        maturity_date: this.maturityDate,
-        description: this.description,
-        client_id: this.clientId,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      fungible: this.fungible,
+      asset_issuer_id: this.assetIssuerId,
+      asset_id: this.assetId,
+      asset_class: this.assetClass,
+      asset_type: this.assetType,
+      asset_status: this.assetStatus,
+      country_id: this.countryId,
+      venue_id: this.venueId,
+      maturity_date: this.maturityDate,
+      description: this.description,
+      client_id: this.clientId,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return NonDeliverableForward;
 }(_fxBase2.default);

--- a/dist/core/Reference/Reference.js
+++ b/dist/core/Reference/Reference.js
@@ -56,19 +56,6 @@ var Reference = function (_AMaaSModel) {
   }
 
   _createClass(Reference, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        reference_value: this.referenceValue,
-        active: this.active,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
-    }
-  }, {
     key: 'active',
     set: function set(newActive) {
       switch (newActive) {
@@ -85,6 +72,21 @@ var Reference = function (_AMaaSModel) {
     get: function get() {
       return this._active;
     }
+
+    /*
+    toJSON() {
+      return {
+        reference_value: this.referenceValue,
+        active: this.active,
+        created_by: this.createdBy,
+        updated_by: this.updatedBy,
+        created_time: this.createdTime,
+        updated_time: this.updatedTime,
+        version: this.version
+      }
+    }
+    */
+
   }]);
 
   return Reference;

--- a/dist/parties/Broker/broker.js
+++ b/dist/parties/Broker/broker.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _company = require('../Company/company.js');
 
 var _company2 = _interopRequireDefault(_company);
@@ -84,27 +82,27 @@ var Broker = function (_Company) {
     }));
   }
 
-  _createClass(Broker, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        party_id: this.partyId,
-        party_status: this.partyStatus,
-        party_class: this.partyClass,
-        party_type: this.partyType,
-        description: this.description,
-        addresses: this.addresses,
-        emails: this.emails,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      party_id: this.partyId,
+      party_status: this.partyStatus,
+      party_class: this.partyClass,
+      party_type: this.partyType,
+      description: this.description,
+      addresses: this.addresses,
+      emails: this.emails,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Broker;
 }(_company2.default);

--- a/dist/parties/Children/address.js
+++ b/dist/parties/Children/address.js
@@ -76,25 +76,6 @@ var Address = function (_AMaaSModel) {
   }
 
   _createClass(Address, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        address_primary: this.addressPrimary,
-        line_one: this.lineOne,
-        line_two: this.lineTwo,
-        city: this.city,
-        region: this.region,
-        postal_code: this.postalCode,
-        country_id: this.countryId,
-        active: this.active,
-        created_by: this.createdBy,
-        created_time: this.createdTime,
-        updated_by: this.updatedBy,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
-    }
-  }, {
     key: 'active',
     set: function set(newActive) {
       switch (newActive) {
@@ -128,6 +109,27 @@ var Address = function (_AMaaSModel) {
     get: function get() {
       return this._addressPrimary;
     }
+
+    /*
+    toJSON() {
+      return {
+        address_primary: this.addressPrimary,
+        line_one: this.lineOne,
+        line_two: this.lineTwo,
+        city: this.city,
+        region: this.region,
+        postal_code: this.postalCode,
+        country_id: this.countryId,
+        active: this.active,
+        created_by: this.createdBy,
+        created_time: this.createdTime,
+        updated_by: this.updatedBy,
+        updated_time: this.updatedTime,
+        version: this.version
+      }
+    }
+    */
+
   }]);
 
   return Address;

--- a/dist/parties/Children/email.js
+++ b/dist/parties/Children/email.js
@@ -60,20 +60,6 @@ var Email = function (_AMaaSModel) {
   }
 
   _createClass(Email, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        email_primary: this.emailPrimary,
-        email: this.email,
-        active: this.active,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
-    }
-  }, {
     key: 'active',
     set: function set(newActive) {
       switch (newActive) {
@@ -107,6 +93,22 @@ var Email = function (_AMaaSModel) {
     get: function get() {
       return this._emailPrimary;
     }
+
+    /*
+    toJSON() {
+      return {
+        email_primary: this.emailPrimary,
+        email: this.email,
+        active: this.active,
+        created_by: this.createdBy,
+        updated_by: this.updatedBy,
+        created_time: this.createdTime,
+        updated_time: this.updatedTime,
+        version: this.version
+      }
+    }
+    */
+
   }]);
 
   return Email;

--- a/dist/parties/Company/company.js
+++ b/dist/parties/Company/company.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _organisation = require('../Organisation/organisation.js');
 
 var _organisation2 = _interopRequireDefault(_organisation);
@@ -86,27 +84,27 @@ var Company = function (_Organisation) {
     }));
   }
 
-  _createClass(Company, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        party_id: this.partyId,
-        party_status: this.partyStatus,
-        party_class: this.partyClass,
-        party_type: this.partyType,
-        description: this.description,
-        addresses: this.addresses,
-        emails: this.emails,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      party_id: this.partyId,
+      party_status: this.partyStatus,
+      party_class: this.partyClass,
+      party_type: this.partyType,
+      description: this.description,
+      addresses: this.addresses,
+      emails: this.emails,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Company;
 }(_organisation2.default);

--- a/dist/parties/Exchange/exchange.js
+++ b/dist/parties/Exchange/exchange.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _company = require('../Company/company.js');
 
 var _company2 = _interopRequireDefault(_company);
@@ -86,27 +84,27 @@ var Exchange = function (_Company) {
     }));
   }
 
-  _createClass(Exchange, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        party_id: this.partyId,
-        party_status: this.partyStatus,
-        party_class: this.partyClass,
-        party_type: this.partyType,
-        description: this.description,
-        addresses: this.addresses,
-        emails: this.emails,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      party_id: this.partyId,
+      party_status: this.partyStatus,
+      party_class: this.partyClass,
+      party_type: this.partyType,
+      description: this.description,
+      addresses: this.addresses,
+      emails: this.emails,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Exchange;
 }(_company2.default);

--- a/dist/parties/Fund/fund.js
+++ b/dist/parties/Fund/fund.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _company = require('../Company/company.js');
 
 var _company2 = _interopRequireDefault(_company);
@@ -86,27 +84,27 @@ var Fund = function (_Company) {
     }));
   }
 
-  _createClass(Fund, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        party_id: this.partyId,
-        party_status: this.partyStatus,
-        party_class: this.partyClass,
-        party_type: this.partyType,
-        description: this.description,
-        addresses: this.addresses,
-        emails: this.emails,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      party_id: this.partyId,
+      party_status: this.partyStatus,
+      party_class: this.partyClass,
+      party_type: this.partyType,
+      description: this.description,
+      addresses: this.addresses,
+      emails: this.emails,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Fund;
 }(_company2.default);

--- a/dist/parties/GovernmentAgency/governmentAgency.js
+++ b/dist/parties/GovernmentAgency/governmentAgency.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _organisation = require('../Organisation/organisation.js');
 
 var _organisation2 = _interopRequireDefault(_organisation);
@@ -86,27 +84,27 @@ var GovernmentAgency = function (_Organisation) {
     }));
   }
 
-  _createClass(GovernmentAgency, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        party_id: this.partyId,
-        party_status: this.partyStatus,
-        party_class: this.partyClass,
-        party_type: this.partyType,
-        description: this.description,
-        addresses: this.addresses,
-        emails: this.emails,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      party_id: this.partyId,
+      party_status: this.partyStatus,
+      party_class: this.partyClass,
+      party_type: this.partyType,
+      description: this.description,
+      addresses: this.addresses,
+      emails: this.emails,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return GovernmentAgency;
 }(_organisation2.default);

--- a/dist/parties/Individual/individual.js
+++ b/dist/parties/Individual/individual.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _party = require('../Party/party.js');
 
 var _party2 = _interopRequireDefault(_party);
@@ -86,27 +84,27 @@ var Individual = function (_Party) {
     }));
   }
 
-  _createClass(Individual, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        party_id: this.partyId,
-        party_status: this.partyStatus,
-        party_class: this.partyClass,
-        party_type: this.partyType,
-        description: this.description,
-        addresses: this.addresses,
-        emails: this.emails,
-        references: this.references,
-        created_by: this.createdBy,
-        created_time: this.createdTime,
-        updated_by: this.updatedBy,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      party_id: this.partyId,
+      party_status: this.partyStatus,
+      party_class: this.partyClass,
+      party_type: this.partyType,
+      description: this.description,
+      addresses: this.addresses,
+      emails: this.emails,
+      references: this.references,
+      created_by: this.createdBy,
+      created_time: this.createdTime,
+      updated_by: this.updatedBy,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Individual;
 }(_party2.default);

--- a/dist/parties/Organisation/organisation.js
+++ b/dist/parties/Organisation/organisation.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _party = require('../Party/party.js');
 
 var _party2 = _interopRequireDefault(_party);
@@ -86,27 +84,27 @@ var Organisation = function (_Party) {
     }));
   }
 
-  _createClass(Organisation, [{
-    key: 'toJSON',
-    value: function toJSON() {
-      return {
-        asset_manager_id: this.assetManagerId,
-        party_id: this.partyId,
-        party_status: this.partyStatus,
-        party_class: this.partyClass,
-        party_type: this.partyType,
-        description: this.description,
-        addresses: this.addresses,
-        emails: this.emails,
-        references: this.references,
-        created_by: this.createdBy,
-        updated_by: this.updatedBy,
-        created_time: this.createdTime,
-        updated_time: this.updatedTime,
-        version: this.version
-      };
+  /*
+  toJSON() {
+    return {
+      asset_manager_id: this.assetManagerId,
+      party_id: this.partyId,
+      party_status: this.partyStatus,
+      party_class: this.partyClass,
+      party_type: this.partyType,
+      description: this.description,
+      addresses: this.addresses,
+      emails: this.emails,
+      references: this.references,
+      created_by: this.createdBy,
+      updated_by: this.updatedBy,
+      created_time: this.createdTime,
+      updated_time: this.updatedTime,
+      version: this.version
     }
-  }]);
+  }
+  */
+
 
   return Organisation;
 }(_party2.default);

--- a/dist/parties/Party/party.js
+++ b/dist/parties/Party/party.js
@@ -151,9 +151,9 @@ var Party = function (_AMaaSModel) {
         throw new Error('Not a valid email');
       }
     }
-  }, {
-    key: 'toJSON',
-    value: function toJSON() {
+
+    /*
+    toJSON() {
       return {
         asset_manager_id: this.assetManagerId,
         party_id: this.partyId,
@@ -169,8 +169,10 @@ var Party = function (_AMaaSModel) {
         created_time: this.createdTime,
         updated_time: this.updatedTime,
         version: this.version
-      };
+      }
     }
+    */
+
   }, {
     key: 'addresses',
     set: function set(newAddresses) {

--- a/dist/transactions/Positions/position.js
+++ b/dist/transactions/Positions/position.js
@@ -64,8 +64,16 @@ var Position = function (_AMaaSModel) {
   }
 
   _createClass(Position, [{
-    key: 'toJSON',
-    value: function toJSON() {
+    key: 'quantity',
+    set: function set(newQuantity) {
+      this._quantity = new _decimal2.default(newQuantity);
+    },
+    get: function get() {
+      return this._quantity;
+    }
+
+    /*
+    toJSON() {
       return {
         asset_manager_id: this.assetManagerId,
         asset_book_id: this.assetBookId,
@@ -81,16 +89,10 @@ var Position = function (_AMaaSModel) {
         updated_by: this.updatedBy,
         created_time: this.createdTime,
         updated_time: this.updatedTime
-      };
+      }
     }
-  }, {
-    key: 'quantity',
-    set: function set(newQuantity) {
-      this._quantity = new _decimal2.default(newQuantity);
-    },
-    get: function get() {
-      return this._quantity;
-    }
+    */
+
   }]);
 
   return Position;

--- a/dist/transactions/Transaction/transaction.js
+++ b/dist/transactions/Transaction/transaction.js
@@ -141,9 +141,9 @@ var Transaction = function (_AMaaSModel) {
       }
       return netCharges;
     }
-  }, {
-    key: 'toJSON',
-    value: function toJSON() {
+
+    /*
+    toJSON() {
       return {
         asset_manager_id: this.assetManagerId,
         asset_book_id: this.assetBookId,
@@ -172,8 +172,10 @@ var Transaction = function (_AMaaSModel) {
         created_time: this.createdTime,
         updated_time: this.updatedTime,
         version: this.version
-      };
+      }
     }
+    */
+
   }, {
     key: 'quantity',
     set: function set() {

--- a/dist/utils/assetManagers/assetManagers.js
+++ b/dist/utils/assetManagers/assetManagers.js
@@ -157,18 +157,19 @@ function deactivate(_ref4, callback) {
 }
 
 function _parseAM(object) {
-  return new _assetManager2.default({
-    assetManagerId: object.asset_manager_id,
-    assetManagerType: object.asset_manager_type,
-    assetManagerStatus: object.asset_manager_status,
-    clientId: object.client_id,
-    partyId: object.party_id,
-    defaultBookOwnerId: object.default_book_owner_id,
-    defaultTimezone: object.default_timezone,
-    defaultBookCloseTime: object.default_book_close_time,
-    createdBy: object.created_by,
-    updatedBy: object.updated_by,
-    createdTime: object.created_time,
-    updatedTime: object.updated_time
-  });
+  return new _assetManager2.default(object);
+  // return new AssetManager({
+  //   assetManagerId: object.asset_manager_id,
+  //   assetManagerType: object.asset_manager_type,
+  //   assetManagerStatus: object.asset_manager_status,
+  //   clientId: object.client_id,
+  //   partyId: object.party_id,
+  //   defaultBookOwnerId: object.default_book_owner_id,
+  //   defaultTimezone: object.default_timezone,
+  //   defaultBookCloseTime: object.default_book_close_time,
+  //   createdBy: object.created_by,
+  //   updatedBy: object.updated_by,
+  //   createdTime: object.created_time,
+  //   updatedTime: object.updated_time
+  // })
 }

--- a/dist/utils/assets/assets.js
+++ b/dist/utils/assets/assets.js
@@ -212,286 +212,298 @@ function _parseAsset(object) {
   var references = (0, _parties._parseChildren)('reference', object.references);
   switch (object.asset_type) {
     case 'Asset':
-      asset = new _assets.Asset({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.Asset(Object.assign(object, { references: references }));
+      // asset = new Asset({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Bond':
-      asset = new _assets.BondBase({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        issueDate: object.issue_date,
-        coupon: object.coupon,
-        par: object.par,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.BondBase(Object.assign(object, { references: references }));
+      // asset = new BondBase({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   issueDate: object.issue_date,
+      //   coupon: object.coupon,
+      //   par: object.par,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'BondCorporate':
-      asset = new _assets.BondCorporate({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        issueDate: object.issue_date,
-        coupon: object.coupon,
-        par: object.par,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.BondCorporate(Object.assign(object, { references: references }));
+      // asset = new BondCorporate({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   issueDate: object.issue_date,
+      //   coupon: object.coupon,
+      //   par: object.par,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'BondGovernment':
-      asset = new _assets.BondGovernment({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        issueDate: object.issue_date,
-        coupon: object.coupon,
-        par: object.par,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.BondGovernment(Object.assign(object, { references: references }));
+      // asset = new BondGovernment({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   issueDate: object.issue_date,
+      //   coupon: object.coupon,
+      //   par: object.par,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'BondMortgage':
-      asset = new _assets.BondMortgage({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        issueDate: object.issue_date,
-        coupon: object.coupon,
-        par: object.par,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.BondMortgage(Object.assign(object, { references: references }));
+      // asset = new BondMortgage({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   issueDate: object.issue_date,
+      //   coupon: object.coupon,
+      //   par: object.par,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Currency':
-      asset = new _assets.Currency({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        deliverable: object.deliverable,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.Currency(Object.assign(object, { references: references }));
+      // asset = new Currency({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   deliverable: object.deliverable,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Derivative':
-      asset = new _assets.Derivative({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        isseuDate: object.issue_date,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.Derivative(Object.assign(object, { references: references }));
+      // asset = new Derivative({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   isseuDate: object.issue_date,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'BondOption':
-      asset = new _assets.BondOption({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        isseuDate: object.issue_date,
-        putCall: object.put_call,
-        strike: object.strike,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.BondOption(Object.assign(object, { references: references }));
+      // asset = new BondOption({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   isseuDate: object.issue_date,
+      //   putCall: object.put_call,
+      //   strike: object.strike,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Equity':
-      asset = new _assets.Equity({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.Equity(Object.assign(object, { references: references }));
+      // asset = new Equity({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'ForeignExchange':
-      asset = new _assets.ForeignExchange({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.ForeignExchange(Object.assign(object, { references: references }));
+      // asset = new ForeignExchange({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'NonDeliverableForward':
-      asset = new _assets.NonDeliverableForward({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.NonDeliverableForward(Object.assign(object, { references: references }));
+      // asset = new NonDeliverableForward({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     default:
-      asset = new _assets.Asset({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        deliverable: object.deliverable,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      asset = new _assets.Asset(Object.assign(object, { references: references }));
+    // asset = new Asset({
+    //   assetManagerId: object.asset_manager_id,
+    //   fungible: object.fungible,
+    //   assetIssuerId: object.asset_issuer_id,
+    //   assetId: object.asset_id,
+    //   assetClass: object.asset_class,
+    //   assetType: object.asset_type,
+    //   assetStatus: object.asset_status,
+    //   countryId: object.country_id,
+    //   venueId: object.venue_id,
+    //   maturityDate: object.maturity_date,
+    //   description: object.description,
+    //   clientId: object.client_id,
+    //   deliverable: object.deliverable,
+    //   references,
+    //   createdBy: object.created_by,
+    //   updatedBy: object.updated_by,
+    //   createdTime: object.created_time,
+    //   updatedTime: object.updated_time,
+    //   version: object.version
+    // })
   }
   return asset;
 }

--- a/dist/utils/books/books.js
+++ b/dist/utils/books/books.js
@@ -86,21 +86,22 @@ function search(_ref2, callback) {
 }
 
 function _parseBook(object) {
-  return new _book2.default({
-    assetManagerId: object.asset_manager_id,
-    bookId: object.book_id,
-    bookStatus: object.book_status,
-    ownerId: object.owner_id,
-    closeTime: object.close_time,
-    timezone: object.timezone,
-    description: object.description,
-    positions: object.positions,
-    createdBy: object.created_by,
-    updatedBy: object.updated_by,
-    createdTime: object.created_time,
-    updatedTime: object.updated_time,
-    version: object.version
-  });
+  return new _book2.default(object);
+  // return new Book({
+  //   assetManagerId: object.asset_manager_id,
+  //   bookId: object.book_id,
+  //   bookStatus: object.book_status,
+  //   ownerId: object.owner_id,
+  //   closeTime: object.close_time,
+  //   timezone: object.timezone,
+  //   description: object.description,
+  //   positions: object.positions,
+  //   createdBy: object.created_by,
+  //   updatedBy: object.updated_by,
+  //   createdTime: object.created_time,
+  //   updatedTime: object.updated_time,
+  //   version: object.version
+  // })
 }
 
 function _handleCallback(error, result, callback) {

--- a/dist/utils/network/index.js
+++ b/dist/utils/network/index.js
@@ -119,7 +119,7 @@ function retrieveData(_ref2, callback) {
     callback(e);
     return;
   }
-  var promise = _superagent2.default.get(url).set('Authorization', token);
+  var promise = _superagent2.default.get(url).set('Authorization', token).query({ camelcase: true });
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(function (response) {
@@ -185,7 +185,7 @@ function insertData(_ref3, callback) {
     url: url,
     json: data
   };
-  var promise = _superagent2.default.post(url).send(data).set('Authorization', token);
+  var promise = _superagent2.default.post(url).send(data).set('Authorization', token).query({ camelcase: true });
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(function (response) {
@@ -231,7 +231,7 @@ function putData(_ref4, callback) {
     url: url,
     json: data
   };
-  var promise = _superagent2.default.put(url).send(data).set('Authorization', token);
+  var promise = _superagent2.default.put(url).send(data).set('Authorization', token).query({ camelcase: true });
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(function (response) {
@@ -277,7 +277,7 @@ function patchData(_ref5, callback) {
     url: url,
     json: data
   };
-  var promise = _superagent2.default.patch(url).send(data).set('Authorization', token);
+  var promise = _superagent2.default.patch(url).send(data).set('Authorization', token).query({ camelcase: true });
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(function (response) {
@@ -318,7 +318,7 @@ function deleteData(_ref6, callback) {
     callback(e);
     return;
   }
-  var promise = _superagent2.default.delete(url).set('Authorization', token);
+  var promise = _superagent2.default.delete(url).set('Authorization', token).query({ camelcase: true });
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(function (response) {
@@ -360,6 +360,7 @@ function searchData(_ref7, callback) {
   var qString = {};
   var qValueString = queryValue.join();
   qString[queryKey] = qValueString;
+  qString.camelcase = true;
   var params = {
     url: url,
     qs: qString

--- a/dist/utils/parties/parties.js
+++ b/dist/utils/parties/parties.js
@@ -250,49 +250,52 @@ function _parseChildren(type, children) {
     case 'address':
       for (var child in children) {
         if (children.hasOwnProperty(child)) {
-          parsedChildren[child] = new _address2.default({
-            addressPrimary: children[child].address_primary,
-            lineOne: children[child].line_one,
-            lineTwo: children[child].line_two,
-            city: children[child].city,
-            region: children[child].region,
-            postalCode: children[child].postal_code,
-            countryId: children[child].country_id,
-            active: children[child].active,
-            createdBy: children[child].created_by,
-            updatedBy: children[child].updated_by,
-            createdTime: children[child].created_time,
-            updatedTime: children[child].updated_time,
-            version: children[child].version
-          });
+          parsedChildren[child] = new _address2.default(children[child]);
+          // parsedChildren[child] = new Address({
+          //   addressPrimary: children[child].address_primary,
+          //   lineOne: children[child].line_one,
+          //   lineTwo: children[child].line_two,
+          //   city: children[child].city,
+          //   region: children[child].region,
+          //   postalCode: children[child].postal_code,
+          //   countryId: children[child].country_id,
+          //   active: children[child].active,
+          //   createdBy: children[child].created_by,
+          //   updatedBy: children[child].updated_by,
+          //   createdTime: children[child].created_time,
+          //   updatedTime: children[child].updated_time,
+          //   version: children[child].version
+          // })
         }
       }
       break;
     case 'email':
       for (var _child in children) {
-        parsedChildren[_child] = new _email2.default({
-          emailPrimary: children[_child].email_primary,
-          email: children[_child].email,
-          active: children[_child].active,
-          createdBy: children[_child].created_by,
-          updatedBy: children[_child].updated_by,
-          createdTime: children[_child].created_time,
-          updatedTime: children[_child].updated_time,
-          version: children[_child].version
-        });
+        parsedChildren[_child] = new _email2.default(children[_child]);
+        // parsedChildren[child] = new Email({
+        //   emailPrimary: children[child].email_primary,
+        //   email: children[child].email,
+        //   active: children[child].active,
+        //   createdBy: children[child].created_by,
+        //   updatedBy: children[child].updated_by,
+        //   createdTime: children[child].created_time,
+        //   updatedTime: children[child].updated_time,
+        //   version: children[child].version
+        // })
       }
       break;
     case 'reference':
       for (var _child2 in children) {
-        parsedChildren[_child2] = new _Reference2.default({
-          referenceValue: children[_child2].reference_value,
-          active: children[_child2].active,
-          createdBy: children[_child2].created_by,
-          updatedBy: children[_child2].updated_by,
-          createdTime: children[_child2].created_time,
-          updatedTime: children[_child2].updated_time,
-          version: children[_child2].version
-        });
+        parsedChildren[_child2] = new _Reference2.default(children[_child2]);
+        // parsedChildren[child] = new Reference({
+        //   referenceValue: children[child].reference_value,
+        //   active: children[child].active,
+        //   createdBy: children[child].created_by,
+        //   updatedBy: children[child].updated_by,
+        //   createdTime: children[child].created_time,
+        //   updatedTime: children[child].updated_time,
+        //   version: children[child].version
+        // })
       }
       break;
     default:
@@ -306,150 +309,158 @@ function _parseParty(object) {
   var addresses = _parseChildren('address', object.addresses);
   var emails = _parseChildren('email', object.emails);
   var references = _parseChildren('reference', object.references);
-  switch (object.party_type) {
+  switch (object.partyType) {
     case 'Individual':
-      party = new _individual2.default({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses: addresses,
-        emails: emails,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      party = new _individual2.default(Object.assign(object, { addresses: addresses, emails: emails, references: references }));
+      // party = new Individual({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Broker':
-      party = new _broker2.default({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses: addresses,
-        emails: emails,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      party = new _broker2.default(Object.assign(object, { addresses: addresses, emails: emails, references: references }));
+      // party = new Broker({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Exchange':
-      party = new _exchange2.default({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses: addresses,
-        emails: emails,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      party = new _exchange2.default(Object.assign(object, { addresses: addresses, emails: emails, references: references }));
+      // party = new Exchange({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Fund':
-      party = new _fund2.default({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses: addresses,
-        emails: emails,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      party = new _fund2.default(Object.assign(object, { addresses: addresses, emails: emails, references: references }));
+      // party = new Fund({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'GovernmentAgency':
-      party = new _governmentAgency2.default({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses: addresses,
-        emails: emails,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      party = new _governmentAgency2.default(Object.assign(object, { addresses: addresses, emails: emails, references: references }));
+      // party = new GovernmentAgency({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Organisation':
-      party = new _organisation2.default({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses: addresses,
-        emails: emails,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      party = new _organisation2.default(Object.assign(object, { addresses: addresses, emails: emails, references: references }));
+      // party = new Organisation({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     case 'Company':
-      party = new _company2.default({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses: addresses,
-        emails: emails,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      party = new _company2.default(Object.assign(object, { addresses: addresses, emails: emails, references: references }));
+      // party = new Company({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break;
     default:
-      party = new _party2.default({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses: addresses,
-        emails: emails,
-        references: references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      });
+      party = new _party2.default(Object.assign(object, { addresses: addresses, emails: emails, references: references }));
+    // party = new Party({
+    //   assetManagerId: object.asset_manager_id,
+    //   partyId: object.party_id,
+    //   partyStatus: object.party_status,
+    //   partyClass: object.party_class,
+    //   partyType: object.party_type,
+    //   description: object.description,
+    //   addresses,
+    //   emails,
+    //   references,
+    //   createdBy: object.created_by,
+    //   updatedBy: object.updated_by,
+    //   createdTime: object.created_time,
+    //   updatedTime: object.updated_time,
+    //   version: object.version
+    // })
   }
   return party;
 }

--- a/dist/utils/parties/parties.js
+++ b/dist/utils/parties/parties.js
@@ -271,31 +271,35 @@ function _parseChildren(type, children) {
       break;
     case 'email':
       for (var _child in children) {
-        parsedChildren[_child] = new _email2.default(children[_child]);
-        // parsedChildren[child] = new Email({
-        //   emailPrimary: children[child].email_primary,
-        //   email: children[child].email,
-        //   active: children[child].active,
-        //   createdBy: children[child].created_by,
-        //   updatedBy: children[child].updated_by,
-        //   createdTime: children[child].created_time,
-        //   updatedTime: children[child].updated_time,
-        //   version: children[child].version
-        // })
+        if (children.hasOwnProperty(_child)) {
+          parsedChildren[_child] = new _email2.default(children[_child]);
+          // parsedChildren[child] = new Email({
+          //   emailPrimary: children[child].email_primary,
+          //   email: children[child].email,
+          //   active: children[child].active,
+          //   createdBy: children[child].created_by,
+          //   updatedBy: children[child].updated_by,
+          //   createdTime: children[child].created_time,
+          //   updatedTime: children[child].updated_time,
+          //   version: children[child].version
+          // })
+        }
       }
       break;
     case 'reference':
       for (var _child2 in children) {
-        parsedChildren[_child2] = new _Reference2.default(children[_child2]);
-        // parsedChildren[child] = new Reference({
-        //   referenceValue: children[child].reference_value,
-        //   active: children[child].active,
-        //   createdBy: children[child].created_by,
-        //   updatedBy: children[child].updated_by,
-        //   createdTime: children[child].created_time,
-        //   updatedTime: children[child].updated_time,
-        //   version: children[child].version
-        // })
+        if (children.hasOwnProperty(_child2)) {
+          parsedChildren[_child2] = new _Reference2.default(children[_child2]);
+          // parsedChildren[child] = new Reference({
+          //   referenceValue: children[child].reference_value,
+          //   active: children[child].active,
+          //   createdBy: children[child].created_by,
+          //   updatedBy: children[child].updated_by,
+          //   createdTime: children[child].created_time,
+          //   updatedTime: children[child].updated_time,
+          //   version: children[child].version
+          // })
+        }
       }
       break;
     default:

--- a/dist/utils/positions/positions.js
+++ b/dist/utils/positions/positions.js
@@ -74,21 +74,22 @@ function search(_ref2, callback) {
 }
 
 function _parsePos(pos) {
-  return new _position2.default({
-    createdBy: pos.created_by,
-    updatedBy: pos.updated_by,
-    createdTime: pos.created_time,
-    updatedTime: pos.updated_time,
-    version: pos.version,
-    assetManagerId: pos.asset_manager_id,
-    assetBookId: pos.asset_book_id,
-    assetId: pos.asset_id,
-    quantity: pos.quantity,
-    validFrom: pos.valid_from,
-    internalId: pos.internal_id,
-    validTo: pos.valid_to,
-    clientId: pos.client_id,
-    accountingType: pos.accounting_type,
-    accountId: pos.account_id
-  });
+  return new _position2.default(pos);
+  // return new Position({
+  //   createdBy: pos.created_by,
+  //   updatedBy: pos.updated_by,
+  //   createdTime: pos.created_time,
+  //   updatedTime: pos.updated_time,
+  //   version: pos.version,
+  //   assetManagerId: pos.asset_manager_id,
+  //   assetBookId: pos.asset_book_id,
+  //   assetId: pos.asset_id,
+  //   quantity: pos.quantity,
+  //   validFrom: pos.valid_from,
+  //   internalId: pos.internal_id,
+  //   validTo: pos.valid_to,
+  //   clientId: pos.client_id,
+  //   accountingType: pos.accounting_type,
+  //   accountId: pos.account_id
+  // })
 }

--- a/src/assetManagers/AssetManager/assetManager.js
+++ b/src/assetManagers/AssetManager/assetManager.js
@@ -40,6 +40,7 @@ class AssetManager extends AMaaSModel {
     this.defaultBookCloseTime = defaultBookCloseTime
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -57,6 +58,7 @@ class AssetManager extends AMaaSModel {
       version: this.version
     }
   }
+  */
 }
 
 export default AssetManager

--- a/src/assetManagers/AssetManager/assetManager.test.js
+++ b/src/assetManagers/AssetManager/assetManager.test.js
@@ -8,12 +8,12 @@ describe('AssetManager', () => {
         createdBy: 'almightyCreator'
       })
       const expectedObj = {
-        asset_manager_id: '48576',
-        created_by: 'almightyCreator',
-        updated_by: 'TEMP',
+        assetManagerId: '48576',
+        createdBy: 'almightyCreator',
+        updatedBy: 'TEMP',
         version: 1
       }
-      expect(JSON.stringify(testAM)).toEqual(JSON.stringify(expectedObj))
+      expect(JSON.parse(JSON.stringify(testAM))).toEqual(expectedObj)
     })
   })
 })

--- a/src/assets/Asset/asset.js
+++ b/src/assets/Asset/asset.js
@@ -68,6 +68,7 @@ class Asset extends AMaaSModel {
     this.references.AMaaS = new Reference({ referenceValue: assetId })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -90,6 +91,7 @@ class Asset extends AMaaSModel {
       version: this.version
     }
   }
+  */
 }
 
 export default Asset

--- a/src/assets/Asset/asset.test.js
+++ b/src/assets/Asset/asset.test.js
@@ -8,5 +8,10 @@ describe('Asset', () => {
       const expectedRef = new Reference({ referenceValue: 'testId' })
       expect(testAsset.references.AMaaS).toEqual(expectedRef)
     })
+
+    it('should stringify correctly', () => {
+      const testAsset = new Asset({ assetId: 'testId' })
+      expect(JSON.parse(JSON.stringify(testAsset)).assetId).toEqual('testId')
+    })
   })
 })

--- a/src/assets/Bond/BondBase/bond.js
+++ b/src/assets/Bond/BondBase/bond.js
@@ -124,6 +124,7 @@ class BondBase extends Asset {
     return this._defaulted
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -149,6 +150,7 @@ class BondBase extends Asset {
       version: this.version
     }
   }
+  */
 }
 
 export default BondBase

--- a/src/assets/Bond/BondBase/bond.test.js
+++ b/src/assets/Bond/BondBase/bond.test.js
@@ -3,6 +3,12 @@ import BondBase from './bond.js'
 import Decimal from 'decimal.js'
 
 describe('BondBase', () => {
+  describe('stringify', () => {
+    it('should stringify and parse correctly', () => {
+      const bond = new BondBase({ clientId: 'testId' })
+      expect(JSON.parse(JSON.stringify(bond)).clientId).toEqual('testId')
+    })
+  })
   describe('constructor', () => {
     describe('coupon get/setter', () => {
       it('should set coupon to 0 if assigned 0', () => {

--- a/src/assets/Bond/BondCorporate/bondCorporate.js
+++ b/src/assets/Bond/BondCorporate/bondCorporate.js
@@ -49,6 +49,7 @@ class BondCorporate extends BondBase {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -74,6 +75,7 @@ class BondCorporate extends BondBase {
       version: this.version
     }
   }
+  */
 }
 
 export default BondCorporate

--- a/src/assets/Bond/BondCorporate/bondCorporate.test.js
+++ b/src/assets/Bond/BondCorporate/bondCorporate.test.js
@@ -1,0 +1,11 @@
+import BondCorporate from './bondCorporate'
+
+describe('BondCorporate', () => {
+  describe('stringify and parse', () => {
+    it('should stringify and parse correctly', () => {
+      const bond = new BondCorporate({ venueId: 'test' })
+      expect(JSON.parse(JSON.stringify(bond)).venueId).toBeDefined()
+      expect(JSON.parse(JSON.stringify(bond)).venueId).toEqual('test')
+    })
+  })
+})

--- a/src/assets/Bond/BondGovernment/bondGovernment.js
+++ b/src/assets/Bond/BondGovernment/bondGovernment.js
@@ -49,6 +49,7 @@ class BondGovernment extends BondBase {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -74,6 +75,7 @@ class BondGovernment extends BondBase {
       version: this.version
     }
   }
+  */
 }
 
 export default BondGovernment

--- a/src/assets/Bond/BondGovernment/bondGovernment.test.js
+++ b/src/assets/Bond/BondGovernment/bondGovernment.test.js
@@ -1,0 +1,11 @@
+import BondGovernment from './bondGovernment'
+
+describe('BondGovernment', () => {
+  describe('stringify/parse', () => {
+    it('should stringify and parse correctly', () => {
+      const test = new BondGovernment({ clientId: 'test' })
+      expect(JSON.parse(JSON.stringify(test)).clientId).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).clientId).toEqual('test')
+    })
+  })
+})

--- a/src/assets/Bond/BondMortgage/bondMortgage.js
+++ b/src/assets/Bond/BondMortgage/bondMortgage.js
@@ -49,6 +49,7 @@ class BondMortgage extends BondBase {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -74,6 +75,7 @@ class BondMortgage extends BondBase {
       version: this.version
     }
   }
+  */
 }
 
 export default BondMortgage

--- a/src/assets/Bond/BondMortgage/bondMortgage.test.js
+++ b/src/assets/Bond/BondMortgage/bondMortgage.test.js
@@ -1,0 +1,11 @@
+import BondMortgage from './bondMortgage'
+
+describe('BondMortgage', () => {
+  describe('stringify/parse', () => {
+    it('should stringify/parse correctly', () => {
+      const test = new BondMortgage({ issueDate: 'today' })
+      expect(JSON.parse(JSON.stringify(test)).issueDate).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).issueDate).toEqual('today')
+    })
+  })
+})

--- a/src/assets/Currency/currency.js
+++ b/src/assets/Currency/currency.js
@@ -45,6 +45,7 @@ class Currency extends Asset {
     this.deliverable = deliverable
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -68,6 +69,7 @@ class Currency extends Asset {
       version: this.version
     }
   }
+  */
 }
 
 export default Currency

--- a/src/assets/Currency/currency.test.js
+++ b/src/assets/Currency/currency.test.js
@@ -1,0 +1,11 @@
+import Currency from './currency'
+
+describe('Currency', () => {
+  describe('stringify/parse', () => {
+    it('should stringify/parse correctly', () => {
+      const test = new Currency({ clientId: 'test' })
+      expect(JSON.parse(JSON.stringify(test)).clientId).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).clientId).toEqual('test')
+    })
+  })
+})

--- a/src/assets/Derivative/BondOption/bondOption.js
+++ b/src/assets/Derivative/BondOption/bondOption.js
@@ -49,6 +49,7 @@ class BondOption extends Derivative {
     this.strike = strike
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -74,6 +75,7 @@ class BondOption extends Derivative {
       version: this.version
     }
   }
+  */
 }
 
 export default BondOption

--- a/src/assets/Derivative/BondOption/bondOption.test.js
+++ b/src/assets/Derivative/BondOption/bondOption.test.js
@@ -1,0 +1,11 @@
+import BondOption from './bondOption'
+
+describe('BondOption', () => {
+  describe('stringify/parse', () => {
+    it('should stringify/parse correctly', () => {
+      const test = new BondOption({ putCall: 'test' })
+      expect(JSON.parse(JSON.stringify(test)).putCall).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).putCall).toEqual('test')
+    })
+  })
+})

--- a/src/assets/Derivative/Derivative/derivative.js
+++ b/src/assets/Derivative/Derivative/derivative.js
@@ -45,6 +45,7 @@ class Derivative extends Asset {
     this.issueDate = issueDate
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -68,6 +69,7 @@ class Derivative extends Asset {
       version: this.version
     }
   }
+  */
 }
 
 export default Derivative

--- a/src/assets/Derivative/Derivative/derivative.test.js
+++ b/src/assets/Derivative/Derivative/derivative.test.js
@@ -1,0 +1,11 @@
+import Derivative from './derivative'
+
+describe('Derivative', ()  => {
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new Derivative({ maturityDate: 'today' })
+      expect(JSON.parse(JSON.stringify(test)).maturityDate).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).maturityDate).toEqual('today')
+    })
+  })
+})

--- a/src/assets/Equity/equity.js
+++ b/src/assets/Equity/equity.js
@@ -43,6 +43,7 @@ class Equity extends Asset {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -65,6 +66,7 @@ class Equity extends Asset {
       version: this.version
     }
   }
+  */
 }
 
 export default Equity

--- a/src/assets/Equity/equity.test.js
+++ b/src/assets/Equity/equity.test.js
@@ -1,0 +1,11 @@
+import Equity from './equity'
+
+describe('Equity', () => {
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new Equity({ venueId: 'test' })
+      expect(JSON.parse(JSON.stringify(test)).venueId).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).venueId).toEqual('test')
+    })
+  })
+})

--- a/src/assets/FX/FXBase/fxBase.js
+++ b/src/assets/FX/FXBase/fxBase.js
@@ -51,6 +51,7 @@ class FXBase extends Asset {
     return this.assetId.slice(3,7)
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -73,6 +74,7 @@ class FXBase extends Asset {
       version: this.version
     }
   }
+  */
 }
 
 export default FXBase

--- a/src/assets/FX/FXBase/fxBase.test.js
+++ b/src/assets/FX/FXBase/fxBase.test.js
@@ -1,0 +1,11 @@
+import FXBase from './fxBase.js'
+
+describe('FXBase', () => {
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new FXBase({ assetStatus: 'Active' })
+      expect(JSON.parse(JSON.stringify(test)).assetStatus).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).assetStatus).toEqual('Active')
+    })
+  })
+})

--- a/src/assets/FX/ForeignExchange/foreignExchange.js
+++ b/src/assets/FX/ForeignExchange/foreignExchange.js
@@ -43,6 +43,7 @@ class ForeignExchange extends FXBase {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -65,6 +66,7 @@ class ForeignExchange extends FXBase {
       version: this.version
     }
   }
+  */
 }
 
 export default ForeignExchange

--- a/src/assets/FX/ForeignExchange/foreignExchange.test.js
+++ b/src/assets/FX/ForeignExchange/foreignExchange.test.js
@@ -1,6 +1,13 @@
 import ForeignExchange from './foreignExchange.js'
 
 describe('ForeignExchange', () => {
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new ForeignExchange({ assetId: 'USDSGD' })
+      expect(JSON.parse(JSON.stringify(test)).assetId).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).assetId).toEqual('USDSGD')
+    })
+  })
   describe('get currency functions', () => {
     const fx = new ForeignExchange({ assetId: 'USDSGD' })
     it('getBaseCurrency should return first 3 characters of assetId', () => {

--- a/src/assets/FX/NonDeliverableForward/nonDeliverableForward.js
+++ b/src/assets/FX/NonDeliverableForward/nonDeliverableForward.js
@@ -43,6 +43,7 @@ class NonDeliverableForward extends FXBase {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -65,6 +66,7 @@ class NonDeliverableForward extends FXBase {
       version: this.version
     }
   }
+  */
 }
 
 export default NonDeliverableForward

--- a/src/assets/FX/NonDeliverableForward/nonDeliverableForward.test.js
+++ b/src/assets/FX/NonDeliverableForward/nonDeliverableForward.test.js
@@ -1,0 +1,11 @@
+import NonDeliverableForward from './nonDeliverableForward.js'
+
+describe('NonDeliverableForward', () => {
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new NonDeliverableForward({ maturityDate: 'today' })
+      expect(JSON.parse(JSON.stringify(test)).maturityDate).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).maturityDate).toEqual('today')
+    })
+  })
+})

--- a/src/core/Reference/Reference.js
+++ b/src/core/Reference/Reference.js
@@ -44,6 +44,7 @@ class Reference extends AMaaSModel {
     return this._active
   }
 
+  /*
   toJSON() {
     return {
       reference_value: this.referenceValue,
@@ -55,6 +56,7 @@ class Reference extends AMaaSModel {
       version: this.version
     }
   }
+  */
 }
 
 export default Reference

--- a/src/core/Reference/reference.test.js
+++ b/src/core/Reference/reference.test.js
@@ -1,6 +1,13 @@
 import Reference from './Reference.js'
 
 describe('Reference', () => {
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new Reference({ updatedBy: 'test' })
+      expect(JSON.parse(JSON.stringify(test)).updatedBy).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).updatedBy).toEqual('test')
+    })
+  })
   describe('constructor', () => {
     it('should set active to true if unassigned', () => {
       const testRef = new Reference({})

--- a/src/parties/Broker/broker.js
+++ b/src/parties/Broker/broker.js
@@ -40,6 +40,7 @@ class Broker extends Company {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -58,6 +59,7 @@ class Broker extends Company {
       version: this.version
     }
   }
+  */
 }
 
 export default Broker

--- a/src/parties/Broker/broker.test.js
+++ b/src/parties/Broker/broker.test.js
@@ -8,6 +8,7 @@ describe('Broker', () => {
     })
     it('should set partyClass to Company', () => {
       const testBroker = new Broker({})
+      console.log(JSON.stringify(testBroker))
       expect(testBroker.partyClass).toEqual('Company')
     })
   })

--- a/src/parties/Children/address.js
+++ b/src/parties/Children/address.js
@@ -74,7 +74,7 @@ class Address extends AMaaSModel {
     return this._addressPrimary
   }
 
-
+  /*
   toJSON() {
     return {
       address_primary: this.addressPrimary,
@@ -92,6 +92,7 @@ class Address extends AMaaSModel {
       version: this.version
     }
   }
+  */
 }
 
 export default Address

--- a/src/parties/Children/email.js
+++ b/src/parties/Children/email.js
@@ -64,6 +64,7 @@ class Email extends AMaaSModel {
     return this._emailPrimary
   }
 
+  /*
   toJSON() {
     return {
       email_primary: this.emailPrimary,
@@ -76,6 +77,7 @@ class Email extends AMaaSModel {
       version: this.version
     }
   }
+  */
 }
 
 export default Email

--- a/src/parties/Company/company.js
+++ b/src/parties/Company/company.js
@@ -42,6 +42,7 @@ class Company extends Organisation {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -60,6 +61,7 @@ class Company extends Organisation {
       version: this.version
     }
   }
+  */
 }
 
 export default Company

--- a/src/parties/Exchange/exchange.js
+++ b/src/parties/Exchange/exchange.js
@@ -42,6 +42,7 @@ class Exchange extends Company {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -60,6 +61,7 @@ class Exchange extends Company {
       version: this.version
     }
   }
+  */
 }
 
 export default Exchange

--- a/src/parties/Fund/fund.js
+++ b/src/parties/Fund/fund.js
@@ -42,6 +42,7 @@ class Fund extends Company {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -60,6 +61,7 @@ class Fund extends Company {
       version: this.version
     }
   }
+  */
 }
 
 export default Fund

--- a/src/parties/GovernmentAgency/governmentAgency.js
+++ b/src/parties/GovernmentAgency/governmentAgency.js
@@ -42,6 +42,7 @@ class GovernmentAgency extends Organisation {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -60,6 +61,7 @@ class GovernmentAgency extends Organisation {
       version: this.version
     }
   }
+  */
 }
 
 export default GovernmentAgency

--- a/src/parties/Individual/individual.js
+++ b/src/parties/Individual/individual.js
@@ -42,6 +42,7 @@ class Individual extends Party {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -60,6 +61,7 @@ class Individual extends Party {
       version: this.version
     }
   }
+  */
 }
 
 export default Individual

--- a/src/parties/Organisation/organisation.js
+++ b/src/parties/Organisation/organisation.js
@@ -42,6 +42,7 @@ class Organisation extends Party {
     })
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -60,6 +61,7 @@ class Organisation extends Party {
       version: this.version
     }
   }
+  */
 }
 
 export default Organisation

--- a/src/parties/Party/party.js
+++ b/src/parties/Party/party.js
@@ -145,6 +145,7 @@ class Party extends AMaaSModel {
     }
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -163,6 +164,7 @@ class Party extends AMaaSModel {
       version: this.version
     }
   }
+  */
 }
 
 export default Party

--- a/src/parties/Party/party.test.js
+++ b/src/parties/Party/party.test.js
@@ -2,6 +2,13 @@ import Party from './party.js'
 import { Address, Email } from '../Children'
 
 describe('Party', () => {
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new Party({ partyId: 'test' })
+      expect(JSON.parse(JSON.stringify(test)).partyId).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).partyId).toEqual('test')
+    })
+  })
   describe('constructor', () => {
     it('should set addresses to empty object if class is instantiated without contacts', () => {
       const testParty = new Party({})

--- a/src/transactions/Positions/position.js
+++ b/src/transactions/Positions/position.js
@@ -47,6 +47,7 @@ class Position extends AMaaSModel {
     return this._quantity
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -65,6 +66,7 @@ class Position extends AMaaSModel {
       updated_time: this.updatedTime
     }
   }
+  */
 }
 
 export default Position

--- a/src/transactions/Positions/position.test.js
+++ b/src/transactions/Positions/position.test.js
@@ -2,9 +2,18 @@ import Decimal from 'decimal.js'
 import Position from './position.js'
 
 describe('Position class', () => {
-  it('should set quantity as a Decimal', () => {
-    const testPos = new Position({ quantity: 5.66753 })
-    expect(testPos.quantity).toBeInstanceOf(Decimal)
-    expect(testPos.quantity).toEqual(new Decimal(5.66753))
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new Position({ quantity: 12, assetBookId: 'test' })
+      expect(JSON.parse(JSON.stringify(test)).assetBookId).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).assetBookId).toEqual('test')
+    })
+  })
+  describe('constructor', () => {
+    it('should set quantity as a Decimal', () => {
+      const testPos = new Position({ quantity: 5.66753 })
+      expect(testPos.quantity).toBeInstanceOf(Decimal)
+      expect(testPos.quantity).toEqual(new Decimal(5.66753))
+    })
   })
 })

--- a/src/transactions/Transaction/Transaction.js
+++ b/src/transactions/Transaction/Transaction.js
@@ -134,6 +134,7 @@ class Transaction extends AMaaSModel {
     return netCharges
   }
 
+  /*
   toJSON() {
     return {
       asset_manager_id: this.assetManagerId,
@@ -165,6 +166,7 @@ class Transaction extends AMaaSModel {
       version: this.version
     }
   }
+  */
 }
 
 export default Transaction

--- a/src/transactions/Transaction/Transaction.test.js
+++ b/src/transactions/Transaction/Transaction.test.js
@@ -8,6 +8,13 @@ describe('Transaction class', () => {
     createdBy: 'testUser',
     createdTime: new Date(2017, 1, 30)
   }
+  describe('serialization', () => {
+    it('should serialize properly', () => {
+      const test = new Transaction({ transactionType: 'Trade' })
+      expect(JSON.parse(JSON.stringify(test)).transactionType).toBeDefined()
+      expect(JSON.parse(JSON.stringify(test)).transactionType).toEqual('Trade')
+    })
+  })
   describe('constructor', () => {
     const data = {
       quantity: 2.54,

--- a/src/utils/assetManagers/assetManagers.js
+++ b/src/utils/assetManagers/assetManagers.js
@@ -118,18 +118,19 @@ export function deactivate({AMId, token}, callback) {
 }
 
 export function _parseAM(object) {
-  return new AssetManager({
-    assetManagerId: object.asset_manager_id,
-    assetManagerType: object.asset_manager_type,
-    assetManagerStatus: object.asset_manager_status,
-    clientId: object.client_id,
-    partyId: object.party_id,
-    defaultBookOwnerId: object.default_book_owner_id,
-    defaultTimezone: object.default_timezone,
-    defaultBookCloseTime: object.default_book_close_time,
-    createdBy: object.created_by,
-    updatedBy: object.updated_by,
-    createdTime: object.created_time,
-    updatedTime: object.updated_time
-  })
+  return new AssetManager(object)
+  // return new AssetManager({
+  //   assetManagerId: object.asset_manager_id,
+  //   assetManagerType: object.asset_manager_type,
+  //   assetManagerStatus: object.asset_manager_status,
+  //   clientId: object.client_id,
+  //   partyId: object.party_id,
+  //   defaultBookOwnerId: object.default_book_owner_id,
+  //   defaultTimezone: object.default_timezone,
+  //   defaultBookCloseTime: object.default_book_close_time,
+  //   createdBy: object.created_by,
+  //   updatedBy: object.updated_by,
+  //   createdTime: object.created_time,
+  //   updatedTime: object.updated_time
+  // })
 }

--- a/src/utils/assets/assets.js
+++ b/src/utils/assets/assets.js
@@ -173,286 +173,298 @@ export function _parseAsset(object) {
   const references = _parseChildren('reference', object.references)
   switch (object.asset_type) {
     case 'Asset':
-      asset = new Asset({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new Asset(Object.assign(object, { references }))
+      // asset = new Asset({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Bond':
-      asset = new BondBase({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        issueDate: object.issue_date,
-        coupon: object.coupon,
-        par: object.par,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new BondBase(Object.assign(object, { references }))
+      // asset = new BondBase({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   issueDate: object.issue_date,
+      //   coupon: object.coupon,
+      //   par: object.par,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'BondCorporate':
-      asset = new BondCorporate({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        issueDate: object.issue_date,
-        coupon: object.coupon,
-        par: object.par,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new BondCorporate(Object.assign(object, { references }))
+      // asset = new BondCorporate({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   issueDate: object.issue_date,
+      //   coupon: object.coupon,
+      //   par: object.par,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'BondGovernment':
-      asset = new BondGovernment({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        issueDate: object.issue_date,
-        coupon: object.coupon,
-        par: object.par,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new BondGovernment(Object.assign(object, { references }))
+      // asset = new BondGovernment({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   issueDate: object.issue_date,
+      //   coupon: object.coupon,
+      //   par: object.par,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'BondMortgage':
-      asset = new BondMortgage({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        issueDate: object.issue_date,
-        coupon: object.coupon,
-        par: object.par,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new BondMortgage(Object.assign(object, { references }))
+      // asset = new BondMortgage({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   issueDate: object.issue_date,
+      //   coupon: object.coupon,
+      //   par: object.par,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Currency':
-      asset = new Currency({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        deliverable: object.deliverable,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new Currency(Object.assign(object, { references }))
+      // asset = new Currency({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   deliverable: object.deliverable,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Derivative':
-      asset = new Derivative({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        isseuDate: object.issue_date,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new Derivative(Object.assign(object, { references }))
+      // asset = new Derivative({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   isseuDate: object.issue_date,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'BondOption':
-      asset = new BondOption({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        isseuDate: object.issue_date,
-        putCall: object.put_call,
-        strike: object.strike,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new BondOption(Object.assign(object, { references }))
+      // asset = new BondOption({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   isseuDate: object.issue_date,
+      //   putCall: object.put_call,
+      //   strike: object.strike,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Equity':
-      asset = new Equity({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new Equity(Object.assign(object, { references }))
+      // asset = new Equity({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'ForeignExchange':
-      asset = new ForeignExchange({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new ForeignExchange(Object.assign(object, { references }))
+      // asset = new ForeignExchange({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'NonDeliverableForward':
-      asset = new NonDeliverableForward({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new NonDeliverableForward(Object.assign(object, { references }))
+      // asset = new NonDeliverableForward({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     default:
-      asset = new Asset({
-        assetManagerId: object.asset_manager_id,
-        fungible: object.fungible,
-        assetIssuerId: object.asset_issuer_id,
-        assetId: object.asset_id,
-        assetClass: object.asset_class,
-        assetType: object.asset_type,
-        assetStatus: object.asset_status,
-        countryId: object.country_id,
-        venueId: object.venue_id,
-        maturityDate: object.maturity_date,
-        description: object.description,
-        clientId: object.client_id,
-        deliverable: object.deliverable,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      asset = new Asset(Object.assign(object, { references }))
+      // asset = new Asset({
+      //   assetManagerId: object.asset_manager_id,
+      //   fungible: object.fungible,
+      //   assetIssuerId: object.asset_issuer_id,
+      //   assetId: object.asset_id,
+      //   assetClass: object.asset_class,
+      //   assetType: object.asset_type,
+      //   assetStatus: object.asset_status,
+      //   countryId: object.country_id,
+      //   venueId: object.venue_id,
+      //   maturityDate: object.maturity_date,
+      //   description: object.description,
+      //   clientId: object.client_id,
+      //   deliverable: object.deliverable,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
   }
   return asset
 }

--- a/src/utils/books/books.js
+++ b/src/utils/books/books.js
@@ -60,21 +60,22 @@ export function search({queryKey, queryValue, token}, callback) {
 }
 
 export function _parseBook(object) {
-  return new Book({
-    assetManagerId: object.asset_manager_id,
-    bookId: object.book_id,
-    bookStatus: object.book_status,
-    ownerId: object.owner_id,
-    closeTime: object.close_time,
-    timezone: object.timezone,
-    description: object.description,
-    positions: object.positions,
-    createdBy: object.created_by,
-    updatedBy: object.updated_by,
-    createdTime: object.created_time,
-    updatedTime: object.updated_time,
-    version: object.version
-  })
+  return new Book(object)
+  // return new Book({
+  //   assetManagerId: object.asset_manager_id,
+  //   bookId: object.book_id,
+  //   bookStatus: object.book_status,
+  //   ownerId: object.owner_id,
+  //   closeTime: object.close_time,
+  //   timezone: object.timezone,
+  //   description: object.description,
+  //   positions: object.positions,
+  //   createdBy: object.created_by,
+  //   updatedBy: object.updated_by,
+  //   createdTime: object.created_time,
+  //   updatedTime: object.updated_time,
+  //   version: object.version
+  // })
 }
 
 function _handleCallback(error, result, callback) {

--- a/src/utils/network/index.js
+++ b/src/utils/network/index.js
@@ -90,7 +90,7 @@ export function retrieveData({ AMaaSClass, AMId, resourceId, token }, callback) 
     callback(e)
     return
   }
-  let promise = request.get(url).set('Authorization', token)
+  let promise = request.get(url).set('Authorization', token).query({ camelcase: true })
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(response => response.body)
@@ -149,7 +149,7 @@ export function insertData({ AMaaSClass, AMId, data, token }, callback) {
     url,
     json: data
   }
-  let promise = request.post(url).send(data).set('Authorization', token)
+  let promise = request.post(url).send(data).set('Authorization', token).query({ camelcase: true })
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(response => response.body)
@@ -187,7 +187,7 @@ export function putData({ AMaaSClass, AMId, resourceId, data, token }, callback)
     url,
     json: data
   }
-  let promise = request.put(url).send(data).set('Authorization', token)
+  let promise = request.put(url).send(data).set('Authorization', token).query({ camelcase: true })
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(response => response.body)
@@ -225,7 +225,7 @@ export function patchData({ AMaaSClass, AMId, resourceId, data, token }, callbac
     url,
     json: data
   }
-  let promise = request.patch(url).send(data).set('Authorization', token)
+  let promise = request.patch(url).send(data).set('Authorization', token).query({ camelcase: true })
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(response => response.body)
@@ -259,7 +259,7 @@ export function deleteData({ AMaaSClass, AMId, resourceId, token }, callback) {
     callback(e)
     return
   }
-  let promise = request.delete(url).set('Authorization', token)
+  let promise = request.delete(url).set('Authorization', token).query({ camelcase: true })
   if (typeof callback !== 'function') {
     // return promise if callback is not provided
     return promise.then(response => response.body)
@@ -294,6 +294,7 @@ export function searchData({ AMaaSClass, queryKey, queryValue, token }, callback
   let qString = {}
   const qValueString = queryValue.join()
   qString[queryKey] = qValueString
+  qString.camelcase = true
   const params = {
     url,
     qs: qString

--- a/src/utils/parties/parties.js
+++ b/src/utils/parties/parties.js
@@ -168,49 +168,52 @@ export function _parseChildren(type, children) {
     case 'address':
       for (let child in children) {
         if (children.hasOwnProperty(child)) {
-          parsedChildren[child] = new Address({
-            addressPrimary: children[child].address_primary,
-            lineOne: children[child].line_one,
-            lineTwo: children[child].line_two,
-            city: children[child].city,
-            region: children[child].region,
-            postalCode: children[child].postal_code,
-            countryId: children[child].country_id,
-            active: children[child].active,
-            createdBy: children[child].created_by,
-            updatedBy: children[child].updated_by,
-            createdTime: children[child].created_time,
-            updatedTime: children[child].updated_time,
-            version: children[child].version
-          })
+          parsedChildren[child] = new Address(children[child])
+          // parsedChildren[child] = new Address({
+          //   addressPrimary: children[child].address_primary,
+          //   lineOne: children[child].line_one,
+          //   lineTwo: children[child].line_two,
+          //   city: children[child].city,
+          //   region: children[child].region,
+          //   postalCode: children[child].postal_code,
+          //   countryId: children[child].country_id,
+          //   active: children[child].active,
+          //   createdBy: children[child].created_by,
+          //   updatedBy: children[child].updated_by,
+          //   createdTime: children[child].created_time,
+          //   updatedTime: children[child].updated_time,
+          //   version: children[child].version
+          // })
         }
       }
       break
     case 'email':
       for (let child in children) {
-        parsedChildren[child] = new Email({
-          emailPrimary: children[child].email_primary,
-          email: children[child].email,
-          active: children[child].active,
-          createdBy: children[child].created_by,
-          updatedBy: children[child].updated_by,
-          createdTime: children[child].created_time,
-          updatedTime: children[child].updated_time,
-          version: children[child].version
-        })
+        parsedChildren[child] = new Email(children[child])
+        // parsedChildren[child] = new Email({
+        //   emailPrimary: children[child].email_primary,
+        //   email: children[child].email,
+        //   active: children[child].active,
+        //   createdBy: children[child].created_by,
+        //   updatedBy: children[child].updated_by,
+        //   createdTime: children[child].created_time,
+        //   updatedTime: children[child].updated_time,
+        //   version: children[child].version
+        // })
       }
       break
     case 'reference':
       for (let child in children) {
-        parsedChildren[child] = new Reference({
-          referenceValue: children[child].reference_value,
-          active: children[child].active,
-          createdBy: children[child].created_by,
-          updatedBy: children[child].updated_by,
-          createdTime: children[child].created_time,
-          updatedTime: children[child].updated_time,
-          version: children[child].version
-        })
+        parsedChildren[child] = new Reference(children[child])
+        // parsedChildren[child] = new Reference({
+        //   referenceValue: children[child].reference_value,
+        //   active: children[child].active,
+        //   createdBy: children[child].created_by,
+        //   updatedBy: children[child].updated_by,
+        //   createdTime: children[child].created_time,
+        //   updatedTime: children[child].updated_time,
+        //   version: children[child].version
+        // })
       }
       break
     default:
@@ -224,150 +227,158 @@ export function _parseParty(object) {
   const addresses = _parseChildren('address', object.addresses)
   const emails = _parseChildren('email', object.emails)
   const references = _parseChildren('reference', object.references)
-  switch (object.party_type) {
+  switch (object.partyType) {
     case 'Individual':
-      party = new Individual({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses,
-        emails,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      party = new Individual(Object.assign(object, { addresses, emails, references }))
+      // party = new Individual({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Broker':
-      party = new Broker({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses,
-        emails,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      party = new Broker(Object.assign(object, { addresses, emails, references }))
+      // party = new Broker({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Exchange':
-      party = new Exchange({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses,
-        emails,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+    party = new Exchange(Object.assign(object, { addresses, emails, references }))
+      // party = new Exchange({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Fund':
-      party = new Fund({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses,
-        emails,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      party = new Fund(Object.assign(object, { addresses, emails, references }))
+      // party = new Fund({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'GovernmentAgency':
-      party = new GovernmentAgency({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses,
-        emails,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      party = new GovernmentAgency(Object.assign(object, { addresses, emails, references }))
+      // party = new GovernmentAgency({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Organisation':
-      party = new Organisation({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses,
-        emails,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      party = new Organisation(Object.assign(object, { addresses, emails, references }))
+      // party = new Organisation({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     case 'Company':
-      party = new Company({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses,
-        emails,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      party = new Company(Object.assign(object, { addresses, emails, references }))
+      // party = new Company({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
       break
     default:
-      party = new Party({
-        assetManagerId: object.asset_manager_id,
-        partyId: object.party_id,
-        partyStatus: object.party_status,
-        partyClass: object.party_class,
-        partyType: object.party_type,
-        description: object.description,
-        addresses,
-        emails,
-        references,
-        createdBy: object.created_by,
-        updatedBy: object.updated_by,
-        createdTime: object.created_time,
-        updatedTime: object.updated_time,
-        version: object.version
-      })
+      party = new Party(Object.assign(object, { addresses, emails, references }))
+      // party = new Party({
+      //   assetManagerId: object.asset_manager_id,
+      //   partyId: object.party_id,
+      //   partyStatus: object.party_status,
+      //   partyClass: object.party_class,
+      //   partyType: object.party_type,
+      //   description: object.description,
+      //   addresses,
+      //   emails,
+      //   references,
+      //   createdBy: object.created_by,
+      //   updatedBy: object.updated_by,
+      //   createdTime: object.created_time,
+      //   updatedTime: object.updated_time,
+      //   version: object.version
+      // })
   }
   return party
 }

--- a/src/utils/parties/parties.js
+++ b/src/utils/parties/parties.js
@@ -189,31 +189,35 @@ export function _parseChildren(type, children) {
       break
     case 'email':
       for (let child in children) {
-        parsedChildren[child] = new Email(children[child])
-        // parsedChildren[child] = new Email({
-        //   emailPrimary: children[child].email_primary,
-        //   email: children[child].email,
-        //   active: children[child].active,
-        //   createdBy: children[child].created_by,
-        //   updatedBy: children[child].updated_by,
-        //   createdTime: children[child].created_time,
-        //   updatedTime: children[child].updated_time,
-        //   version: children[child].version
-        // })
+        if (children.hasOwnProperty(child)) {
+          parsedChildren[child] = new Email(children[child])
+          // parsedChildren[child] = new Email({
+          //   emailPrimary: children[child].email_primary,
+          //   email: children[child].email,
+          //   active: children[child].active,
+          //   createdBy: children[child].created_by,
+          //   updatedBy: children[child].updated_by,
+          //   createdTime: children[child].created_time,
+          //   updatedTime: children[child].updated_time,
+          //   version: children[child].version
+          // })
+        }
       }
       break
     case 'reference':
       for (let child in children) {
-        parsedChildren[child] = new Reference(children[child])
-        // parsedChildren[child] = new Reference({
-        //   referenceValue: children[child].reference_value,
-        //   active: children[child].active,
-        //   createdBy: children[child].created_by,
-        //   updatedBy: children[child].updated_by,
-        //   createdTime: children[child].created_time,
-        //   updatedTime: children[child].updated_time,
-        //   version: children[child].version
-        // })
+        if (children.hasOwnProperty(child)) {
+          parsedChildren[child] = new Reference(children[child])
+          // parsedChildren[child] = new Reference({
+          //   referenceValue: children[child].reference_value,
+          //   active: children[child].active,
+          //   createdBy: children[child].created_by,
+          //   updatedBy: children[child].updated_by,
+          //   createdTime: children[child].created_time,
+          //   updatedTime: children[child].updated_time,
+          //   version: children[child].version
+          // })
+        }
       }
       break
     default:

--- a/src/utils/parties/parties.test.js
+++ b/src/utils/parties/parties.test.js
@@ -124,22 +124,22 @@ describe('parties util functions', () => {
         version: 1,
       })
       const party = _parseParty({
-        party_type: 'Individual',
+        partyType: 'Individual',
         addresses: {
           Registered: {
            city: "NODC740NZO",
-           address_primary: true,
-           updated_by: "TEMP",
-           internal_id :4,
-           line_one: "VCF5H1W9KLAAN8DIJ0R4",
+           addressPrimary: true,
+           updatedBy: "TEMP",
+           internalId :4,
+           lineOne: "VCF5H1W9KLAAN8DIJ0R4",
            region: "SX3JEVA03B",
-           country_id: "O21",
-           created_by: "TEMP",
-           updated_time: "2017-01-27T00:31:02",
-           created_time: "2017-01-27T00:31:02",
+           countryId: "O21",
+           createdBy: "TEMP",
+           updatedTime: "2017-01-27T00:31:02",
+           createdTime: "2017-01-27T00:31:02",
            version: 1,
-           postal_code: "YUIJDP",
-           line_two: null,
+           postalCode: "YUIJDP",
+           lineTwo: null,
            active: true
           }
         }

--- a/src/utils/positions/positions.js
+++ b/src/utils/positions/positions.js
@@ -49,21 +49,22 @@ export function search({queryKey, queryValue, token}, callback) {
 }
 
 export function _parsePos(pos) {
-  return new Position({
-    createdBy: pos.created_by,
-    updatedBy: pos.updated_by,
-    createdTime: pos.created_time,
-    updatedTime: pos.updated_time,
-    version: pos.version,
-    assetManagerId: pos.asset_manager_id,
-    assetBookId: pos.asset_book_id,
-    assetId: pos.asset_id,
-    quantity: pos.quantity,
-    validFrom: pos.valid_from,
-    internalId: pos.internal_id,
-    validTo: pos.valid_to,
-    clientId: pos.client_id,
-    accountingType: pos.accounting_type,
-    accountId: pos.account_id
-  })
+  return new Position(pos)
+  // return new Position({
+  //   createdBy: pos.created_by,
+  //   updatedBy: pos.updated_by,
+  //   createdTime: pos.created_time,
+  //   updatedTime: pos.updated_time,
+  //   version: pos.version,
+  //   assetManagerId: pos.asset_manager_id,
+  //   assetBookId: pos.asset_book_id,
+  //   assetId: pos.asset_id,
+  //   quantity: pos.quantity,
+  //   validFrom: pos.valid_from,
+  //   internalId: pos.internal_id,
+  //   validTo: pos.valid_to,
+  //   clientId: pos.client_id,
+  //   accountingType: pos.accounting_type,
+  //   accountId: pos.account_id
+  // })
 }


### PR DESCRIPTION
Remove all custom toJSON() methods and parse[Class] methods previously used to parse snake case to camel case and vice versa. It needs to be removed to restore default functionality to the JSON.stringify() method.